### PR TITLE
Add definition of REDIS_DB environmental variable

### DIFF
--- a/charts/weblate/Chart.yaml
+++ b/charts/weblate/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "4.0.4"
 description: Weblate is a free web-based translation management system.
 name: weblate
-version: 0.1.8
+version: 0.1.9
 home: https://weblate.org/
 icon: https://s.weblate.org/cdn/weblate.svg
 maintainers:

--- a/charts/weblate/README.md
+++ b/charts/weblate/README.md
@@ -2,7 +2,7 @@ weblate
 =======
 Weblate is a free web-based translation management system.
 
-Current chart version is `0.1.8`
+Current chart version is `0.1.9`
 
 Source code can be found [here](https://weblate.org/)
 

--- a/charts/weblate/README.md
+++ b/charts/weblate/README.md
@@ -56,8 +56,8 @@ $ helm install my-release weblate/weblate
 | postgresql.postgresqlDatabase | string | `"weblate"` |  |
 | postgresql.postgresqlPassword | string | `"weblate"` |  |
 | redis.cluster.enabled | bool | `false` |  |
+| redis.db | int | `1` |  |
 | redis.password | string | `"weblate"` |  |
-| redis.db | int | `1` | The Redis database number, defaults to `1`. |
 | replicaCount | int | `1` |  |
 | resources | object | `{}` |  |
 | securityContext | object | `{}` |  |

--- a/charts/weblate/README.md
+++ b/charts/weblate/README.md
@@ -57,6 +57,7 @@ $ helm install my-release weblate/weblate
 | postgresql.postgresqlPassword | string | `"weblate"` |  |
 | redis.cluster.enabled | bool | `false` |  |
 | redis.password | string | `"weblate"` |  |
+| redis.db | int | `1` | The Redis database number, defaults to `1`. |
 | replicaCount | int | `1` |  |
 | resources | object | `{}` |  |
 | securityContext | object | `{}` |  |

--- a/charts/weblate/templates/deployment.yaml
+++ b/charts/weblate/templates/deployment.yaml
@@ -57,6 +57,8 @@ spec:
                   key: postgresql-password
             - name: REDIS_HOST
               value: "{{ include "weblate.redis.fullname" . }}"
+            - name: REDIS_DB
+              value: "{{ .Values.redis.db }}"
             - name: REDIS_PASSWORD
               valueFrom:
                 secretKeyRef:

--- a/charts/weblate/values.yaml
+++ b/charts/weblate/values.yaml
@@ -117,5 +117,6 @@ postgresql:
 
 redis:
   password: "weblate"
+  db: 1
   cluster:
     enabled: false


### PR DESCRIPTION
Allow the configuration of the REDIS_DB from the `values.yaml` file