### PR TITLE
Add support for using an existing volume claim

### DIFF
--- a/charts/weblate/Chart.yaml
+++ b/charts/weblate/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "4.3.2"
 description: Weblate is a free web-based translation management system.
 name: weblate
-version: 0.2.7
+version: 0.2.8
 home: https://weblate.org/
 icon: https://s.weblate.org/cdn/weblate.svg
 maintainers:

--- a/charts/weblate/README.md
+++ b/charts/weblate/README.md
@@ -53,7 +53,7 @@ $ helm install my-release weblate/weblate
 | nodeSelector | object | `{}` |  |
 | persistence.accessMode | string | `"ReadWriteOnce"` |  |
 | persistence.enabled | bool | `true` |  |
-| persistence.existingClaim | string | `""` | Use an existing volume claim  |
+| persistence.existingClaim | string | `""` | Use an existing volume claim |
 | persistence.filestore_dir | string | `"/app/data"` |  |
 | persistence.size | string | `"10Gi"` |  |
 | podSecurityContext.fsGroup | int | `1000` |  |

--- a/charts/weblate/README.md
+++ b/charts/weblate/README.md
@@ -2,7 +2,7 @@ weblate
 =======
 Weblate is a free web-based translation management system.
 
-Current chart version is `0.2.7`
+Current chart version is `0.2.8`
 
 Source code can be found [here](https://weblate.org/)
 

--- a/charts/weblate/README.md
+++ b/charts/weblate/README.md
@@ -53,6 +53,7 @@ $ helm install my-release weblate/weblate
 | nodeSelector | object | `{}` |  |
 | persistence.accessMode | string | `"ReadWriteOnce"` |  |
 | persistence.enabled | bool | `true` |  |
+| persistence.existingClaim | string | `""` | Use an existing volume claim  |
 | persistence.filestore_dir | string | `"/app/data"` |  |
 | persistence.size | string | `"10Gi"` |  |
 | podSecurityContext.fsGroup | int | `1000` |  |

--- a/charts/weblate/templates/deployment.yaml
+++ b/charts/weblate/templates/deployment.yaml
@@ -142,7 +142,7 @@ spec:
         - name: weblate-data
         {{- if .Values.persistence.enabled }}
           persistentVolumeClaim:
-            claimName: {{ include "weblate.fullname" . }}
+            claimName: {{ .Values.persistence.existingClaim | default ( include "weblate.fullname" . ) }}
         {{- else }}
           emptyDir: {}
         {{- end -}}

--- a/charts/weblate/templates/pvc.yaml
+++ b/charts/weblate/templates/pvc.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.persistence.enabled }}
+{{- if and .Values.persistence.enabled ( not .Values.persistence.existingClaim ) }}
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:

--- a/charts/weblate/values.yaml
+++ b/charts/weblate/values.yaml
@@ -96,6 +96,8 @@ ingress:
 persistence:
   enabled: true
 
+  existingClaim: ""
+
   # storageClass: "-"
 
   accessMode: ReadWriteOnce

--- a/charts/weblate/values.yaml
+++ b/charts/weblate/values.yaml
@@ -96,6 +96,7 @@ ingress:
 persistence:
   enabled: true
 
+  # existingClaim -- Use an existing volume claim
   existingClaim: ""
 
   # storageClass: "-"

--- a/charts/weblate/values.yaml
+++ b/charts/weblate/values.yaml
@@ -96,7 +96,7 @@ ingress:
 persistence:
   enabled: true
 
-  # existingClaim -- Use an existing volume claim
+  # -- Use an existing volume claim
   existingClaim: ""
 
   # storageClass: "-"

--- a/charts/weblate/values.yaml
+++ b/charts/weblate/values.yaml
@@ -96,7 +96,7 @@ ingress:
 persistence:
   enabled: true
 
-  # -- Use an existing volume claim
+  # persistence.existingClaim -- Use an existing volume claim
   existingClaim: ""
 
   # storageClass: "-"


### PR DESCRIPTION
## Proposed changes

This PR adds the possibility to use an already existing PersistentVolumeClaim as storage volume for the Weblate deployment. We try to handle the volume claims outside of our helm releases to make sure that the removal of a release does not remove the volume too.

If the value `persistence.existingClaim` is set to non-empty, the content of `pvc.yaml` is not rendered and the deployment uses the configured `claimName` in the `weblate-data` volume.
Otherwise, if `existingClaim` is empty original functionality is preserved, a pvc is created and used in the the deployment.
The default value for `persistence.existingClaim` is an empty string.