### PR TITLE
fix: missing `postgresqlUsername` in `values.yaml` causes helm to fail when `postgresql.enabled` is set to false

### DIFF
--- a/charts/weblate/values.yaml
+++ b/charts/weblate/values.yaml
@@ -126,6 +126,7 @@ tolerations: []
 affinity: {}
 
 postgresql:
+  postgresqlUsername: "weblate"
   postgresqlPassword: "weblate"
   postgresqlDatabase: "weblate"
   service:


### PR DESCRIPTION
On build attempts, when `postgresql.enabled` was set to `false` & instance was configured to connect to a pre-existing postgres instance, the following error may be observed:

`Error: template: weblate/templates/secret.yaml:9:62: executing "weblate/templates/secret.yaml" at <b64enc>: invalid value; expected string`

This is because `postgresql.postgresqlUsername` is required, but not included in the default `values.yaml` file. This PR, quite simply, adds it. This seems to fix the issue on my side.