### PR TITLE
Support for extra secret variables

### DIFF
--- a/charts/weblate/Chart.yaml
+++ b/charts/weblate/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: "4.5.1"
 description: Weblate is a free web-based translation management system.
 name: weblate
 type: application
-version: 0.3.1
+version: 0.3.2
 home: https://weblate.org/
 icon: https://s.weblate.org/cdn/weblate.svg
 maintainers:

--- a/charts/weblate/README.md
+++ b/charts/weblate/README.md
@@ -1,6 +1,6 @@
 # weblate
 
-![Version: 0.3.1](https://img.shields.io/badge/Version-0.3.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 4.5.1](https://img.shields.io/badge/AppVersion-4.5.1-informational?style=flat-square)
+![Version: 0.3.2](https://img.shields.io/badge/Version-0.3.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 4.5.1](https://img.shields.io/badge/AppVersion-4.5.1-informational?style=flat-square)
 
 Weblate is a free web-based translation management system.
 

--- a/charts/weblate/README.md
+++ b/charts/weblate/README.md
@@ -45,8 +45,8 @@ $ helm install my-release weblate/weblate
 | emailSSL | bool | `true` | Use SSL when sending emails |
 | emailTLS | bool | `true` | Use TLS when sending emails |
 | emailUser | string | `""` | User name for sending emails |
-| extraConfig | object | `{}` | Additional (environment) configs. Will be evaluated as Helm template See https://docs.weblate.org/en/latest/admin/install/docker.html#docker-environment |
-| extraSecretConfig | object | `{}` | Same as above, but created as Kubernetes Secret |
+| extraConfig | object | `{}` | Additional (environment) configs. Values will be evaluated as templates. See https://docs.weblate.org/en/latest/admin/install/docker.html#docker-environment |
+| extraSecretConfig | object | `{}` | Same as `extraConfig`, but created as secrets. Values will be evaluated as Helm templates |
 | fullnameOverride | string | `""` |  |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | image.repository | string | `"weblate/weblate"` |  |

--- a/charts/weblate/README.md
+++ b/charts/weblate/README.md
@@ -45,7 +45,8 @@ $ helm install my-release weblate/weblate
 | emailSSL | bool | `true` | Use SSL when sending emails |
 | emailTLS | bool | `true` | Use TLS when sending emails |
 | emailUser | string | `""` | User name for sending emails |
-| extraConfig | object | `{}` | Additional (environment) configs. See https://docs.weblate.org/en/latest/admin/install/docker.html#docker-environment |
+| extraConfig | object | `{}` | Additional (environment) configs. Will be evaluated as Helm template See https://docs.weblate.org/en/latest/admin/install/docker.html#docker-environment |
+| extraSecretConfig | object | `{}` | Same as above, but created as Kubernetes Secret |
 | fullnameOverride | string | `""` |  |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | image.repository | string | `"weblate/weblate"` |  |

--- a/charts/weblate/templates/configmap.yaml
+++ b/charts/weblate/templates/configmap.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "weblate.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
 {{ include "weblate.labels" . | indent 4 }}
 data:

--- a/charts/weblate/templates/deployment.yaml
+++ b/charts/weblate/templates/deployment.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "weblate.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
 {{ include "weblate.labels" . | indent 4 }}
 spec:
@@ -17,6 +18,7 @@ spec:
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
         checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
+        checksum/secret-env: {{ .Values.extraSecretConfig | toYaml | sha256sum }}
       labels:
         app.kubernetes.io/name: {{ include "weblate.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
@@ -107,9 +109,15 @@ spec:
             - name: WEBLATE_DEBUG
               value: "{{ .Values.debug }}"
             {{- range $key, $value := .Values.extraConfig }}
-            - name: {{ $key }}
-              value: "{{ $value }}"
+            - name: {{ $key | quote }}
+              value: |-
+                {{- tpl $value $ | nindent 16 }}
             {{- end }}
+          {{- if .Values.extraSecretConfig }}
+          envFrom:
+            - secretRef:
+                name: {{ include "weblate.fullname" . }}-env
+          {{- end }}
           livenessProbe:
             httpGet:
               path: /healthz/

--- a/charts/weblate/templates/ingress.yaml
+++ b/charts/weblate/templates/ingress.yaml
@@ -9,6 +9,7 @@ apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
   name: {{ $fullName }}
+  namespace: {{ .Release.Namespace }}
   labels:
 {{ include "weblate.labels" . | indent 4 }}
   {{- with .Values.ingress.annotations }}

--- a/charts/weblate/templates/pvc.yaml
+++ b/charts/weblate/templates/pvc.yaml
@@ -3,6 +3,7 @@ kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
   name: {{ include "weblate.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
 {{ include "weblate.labels" . | indent 4 }}
 spec:

--- a/charts/weblate/templates/secret-env.yaml
+++ b/charts/weblate/templates/secret-env.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.extraSecretConfig -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "weblate.fullname" . }}-env
+  namespace: {{ .Release.Namespace }}
+  labels:
+{{ include "weblate.labels" . | indent 4 }}
+type: Opaque
+data:
+  {{- range $key, $value := .Values.extraSecretConfig }}
+  {{ $key }}: {{ tpl $value $ | b64enc | quote }}
+  {{- end }}
+{{- end -}}

--- a/charts/weblate/templates/secret.yaml
+++ b/charts/weblate/templates/secret.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ include "weblate.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
 {{ include "weblate.labels" . | indent 4 }}
 type: Opaque

--- a/charts/weblate/templates/service.yaml
+++ b/charts/weblate/templates/service.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "weblate.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
 {{ include "weblate.labels" . | indent 4 }}
 spec:

--- a/charts/weblate/templates/serviceaccount.yaml
+++ b/charts/weblate/templates/serviceaccount.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ template "weblate.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
 {{ include "weblate.labels" . | indent 4 }}
 {{- end -}}

--- a/charts/weblate/values.yaml
+++ b/charts/weblate/values.yaml
@@ -52,6 +52,9 @@ debug: "0"
 # extraConfig -- Additional (environment) configs. See https://docs.weblate.org/en/latest/admin/install/docker.html#docker-environment
 extraConfig: {}
 
+# Same as extraConfig, but created as secrets. Values will be evaluated as Helm templates
+extraSecretConfig: {}
+
 # configOverride -- Config override. See https://docs.weblate.org/en/latest/admin/install/docker.html#custom-configuration-files
 configOverride: ""
 

--- a/charts/weblate/values.yaml
+++ b/charts/weblate/values.yaml
@@ -49,10 +49,10 @@ allowedHosts: "*"
 # debug -- Enable debugging
 debug: "0"
 
-# extraConfig -- Additional (environment) configs. See https://docs.weblate.org/en/latest/admin/install/docker.html#docker-environment
+# extraConfig -- Additional (environment) configs. Values will be evaluated as templates. See https://docs.weblate.org/en/latest/admin/install/docker.html#docker-environment
 extraConfig: {}
 
-# Same as extraConfig, but created as secrets. Values will be evaluated as Helm templates
+# extraSecretConfig -- Same as `extraConfig`, but created as secrets. Values will be evaluated as Helm templates
 extraSecretConfig: {}
 
 # configOverride -- Config override. See https://docs.weblate.org/en/latest/admin/install/docker.html#custom-configuration-files


### PR DESCRIPTION
## Proposed changes

This PR implements a few Helm chart improvements:

* Support for extra environment variables to be passed as Kubernetes `Secret` (so they can be referenced in `settings-override.py` with `os.environ`)
* For all environment variables (Secret or not), support for multiline values and evaluating as Helm templates (so can include {{}} placeholders)
* Support for Namespaces

## Checklist

- [ ] Lint and unit tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added documentation to describe my feature.
- [ ] I have squashed my commits into logic units.
- [ ] I have described the changes in the commit messages.

## Other information

