### PR TITLE
Enable annotations in the Weblate service

### DIFF
--- a/charts/weblate/Chart.yaml
+++ b/charts/weblate/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: "4.5.2"
 description: Weblate is a free web-based translation management system.
 name: weblate
 type: application
-version: 0.3.3
+version: 0.3.4
 home: https://weblate.org/
 icon: https://s.weblate.org/cdn/weblate.svg
 maintainers:

--- a/charts/weblate/README.md
+++ b/charts/weblate/README.md
@@ -1,6 +1,6 @@
 # weblate
 
-![Version: 0.3.3](https://img.shields.io/badge/Version-0.3.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 4.5.2](https://img.shields.io/badge/AppVersion-4.5.2-informational?style=flat-square)
+![Version: 0.3.4](https://img.shields.io/badge/Version-0.3.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 4.5.2](https://img.shields.io/badge/AppVersion-4.5.2-informational?style=flat-square)
 
 Weblate is a free web-based translation management system.
 
@@ -80,9 +80,9 @@ $ helm install my-release weblate/weblate
 | resources | object | `{}` |  |
 | securityContext | object | `{}` |  |
 | serverEmail | string | `""` | Sender for outgoing emails |
+| service.annotations | string | `nil` |  |
 | service.port | int | `80` |  |
 | service.type | string | `"ClusterIP"` |  |
-| service.annotations | string | `nil` |  |
 | serviceAccount.create | bool | `true` |  |
 | serviceAccount.name | string | `nil` |  |
 | siteDomain | string | `"chart-example.local"` | Site domain |

--- a/charts/weblate/README.md
+++ b/charts/weblate/README.md
@@ -82,6 +82,7 @@ $ helm install my-release weblate/weblate
 | serverEmail | string | `""` | Sender for outgoing emails |
 | service.port | int | `80` |  |
 | service.type | string | `"ClusterIP"` |  |
+| service.annotations | string | `nil` |  |
 | serviceAccount.create | bool | `true` |  |
 | serviceAccount.name | string | `nil` |  |
 | siteDomain | string | `"chart-example.local"` | Site domain |

--- a/charts/weblate/templates/service.yaml
+++ b/charts/weblate/templates/service.yaml
@@ -3,6 +3,10 @@ kind: Service
 metadata:
   name: {{ include "weblate.fullname" . }}
   namespace: {{ .Release.Namespace }}
+  annotations:
+    {{- range $key, $value := .Values.service.annotations }}
+    {{ $key }}: {{ include "common.tplvalues.render" (dict "value" $value "context" $) | quote }}
+    {{- end }}  
   labels:
 {{ include "weblate.labels" . | indent 4 }}
 spec:

--- a/charts/weblate/values.yaml
+++ b/charts/weblate/values.yaml
@@ -80,6 +80,8 @@ securityContext:
 service:
   type: ClusterIP
   port: 80
+  # Service annotations, use key:value pairs
+  annotations:
 
 ingress:
   enabled: false


### PR DESCRIPTION
## Proposed changes

<!--
Describe the big picture of your changes here to communicate to the maintainers
why we should accept this pull request. If it fixes a bug or resolves a feature
request, be sure to link to that issue.
-->

Hello Weblate developers,

I would like to use annotations in the service created by this helm chart. This would allow me to use this helm chart in my Kubernetes configuration, with some external load balancers and multiple ingresses.

Many thanks for a review in advance,
Szymon

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask. We're here to
help! This is simply a reminder of what we are going to look for before merging
your code.
-->

- [X] Lint and unit tests pass locally with my changes.
- [X] I have added tests that prove my fix is effective or that my feature works.
- [X] I have added documentation to describe my feature.
- [X] I have squashed my commits into logic units.
- [X] I have described the changes in the commit messages.

## Other information

<!--
Any other information that is important to this PR such as screenshots of how
the component looks before and after the change.
-->
