### PR TITLE
Add externalSecretName option to populate env from existing secret

### DIFF
--- a/charts/weblate/templates/deployment.yaml
+++ b/charts/weblate/templates/deployment.yaml
@@ -41,6 +41,7 @@ spec:
               containerPort: 8080
               protocol: TCP
           env:
+            {{- if .Values.postgresql.enabled }}
             - name: POSTGRES_DATABASE
               value: "{{ .Values.postgresql.postgresqlDatabase }}"
             - name: POSTGRES_HOST
@@ -57,6 +58,8 @@ spec:
                 secretKeyRef:
                   name: {{ include "weblate.fullname" . }}
                   key: postgresql-password
+            {{- end }}
+            {{- if .Values.redis.enabled }}
             - name: REDIS_HOST
               value: "{{ .Values.redis.redisHost | default (include "weblate.redis.fullname" .) }}"
             - name: REDIS_DB
@@ -66,6 +69,7 @@ spec:
                 secretKeyRef:
                   name: {{ include "weblate.fullname" . }}
                   key: redis-password
+            {{- end }}
             - name: WEBLATE_ADMIN_EMAIL
               value: "{{ .Values.adminEmail }}"
             - name: WEBLATE_ADMIN_NAME

--- a/charts/weblate/templates/deployment.yaml
+++ b/charts/weblate/templates/deployment.yaml
@@ -113,10 +113,16 @@ spec:
               value: |-
                 {{- tpl $value $ | nindent 16 }}
             {{- end }}
-          {{- if .Values.extraSecretConfig }}
+          {{- if (or .Values.extraSecretConfig .Values.externalSecretName) }}
           envFrom:
+            {{- if .Values.extraSecretConfig }}
             - secretRef:
                 name: {{ include "weblate.fullname" . }}-env
+            {{- end }}
+            {{- if .Values.externalSecretName }}
+            - secretRef:
+                name: {{ .Values.externalSecretName }}
+            {{- end }}
           {{- end }}
           livenessProbe:
             httpGet:

--- a/charts/weblate/values.yaml
+++ b/charts/weblate/values.yaml
@@ -55,6 +55,10 @@ extraConfig: {}
 # extraSecretConfig -- Same as `extraConfig`, but created as secrets. Values will be evaluated as Helm templates
 extraSecretConfig: {}
 
+# An external secret, in the same namespace, that will be use to set additionnal
+# (environment) configs.
+externalSecretName: ""
+
 # configOverride -- Config override. See https://docs.weblate.org/en/latest/admin/install/docker.html#custom-configuration-files
 configOverride: ""
 


### PR DESCRIPTION
## Proposed changes

We are deploying using reckoner and are versioning our values.yaml file and don't want to store any secret in the repo. This PR allows to specify some part of the env using a pre-existing secret.

This PR also prevents the generation of environment variables related to redis/postgres when they aren't enabled

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask. We're here to
help! This is simply a reminder of what we are going to look for before merging
your code.
-->

- [ ] Lint and unit tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added documentation to describe my feature.
- [x] I have squashed my commits into logic units.
- [x] I have described the changes in the commit messages.
