### PR TITLE
When enabled is set to false for Postgres and/or Redis, none of the E…

### DIFF
--- a/charts/weblate/templates/deployment.yaml
+++ b/charts/weblate/templates/deployment.yaml
@@ -41,7 +41,6 @@ spec:
               containerPort: 8080
               protocol: TCP
           env:
-            {{- if .Values.postgresql.enabled }}
             - name: POSTGRES_DATABASE
               value: "{{ .Values.postgresql.postgresqlDatabase }}"
             - name: POSTGRES_HOST
@@ -58,8 +57,6 @@ spec:
                 secretKeyRef:
                   name: {{ include "weblate.fullname" . }}
                   key: postgresql-password
-            {{- end }}
-            {{- if .Values.redis.enabled }}
             - name: REDIS_HOST
               value: "{{ .Values.redis.redisHost | default (include "weblate.redis.fullname" .) }}"
             - name: REDIS_DB
@@ -69,7 +66,6 @@ spec:
                 secretKeyRef:
                   name: {{ include "weblate.fullname" . }}
                   key: redis-password
-            {{- end }}
             - name: WEBLATE_ADMIN_EMAIL
               value: "{{ .Values.adminEmail }}"
             - name: WEBLATE_ADMIN_NAME


### PR DESCRIPTION
## Proposed changes

When "enabled" is set to "false" for Postgresql and/or Redis in values.yaml, none of the EnvVars is set due to the if-condition in the deployment.yaml. This results in an error when Weblate is starting. When "enabled" is set to "true" the values are used, but a postgres/redis instance is created which is never used as postgresqlHost/redisHost are set.

As POSTGRES_HOST - EnvVar/ REDIS_HOST -Envar is set to default when postgressqlHost/redisHost is empty, no condition is needed. 

## Checklist

- [ X] Lint and unit tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added documentation to describe my feature.
- [ ] I have squashed my commits into logic units.
- [ X] I have described the changes in the commit messages.

