### PR TITLE
allow to disable security context.

### DIFF
--- a/charts/weblate/Chart.yaml
+++ b/charts/weblate/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 4.14
 description: Weblate is a free web-based translation management system.
 name: weblate
 type: application
-version: 0.4.13
+version: 0.4.14
 home: https://weblate.org/
 icon: https://s.weblate.org/cdn/weblate.svg
 maintainers:

--- a/charts/weblate/README.md
+++ b/charts/weblate/README.md
@@ -39,6 +39,7 @@ $ helm install my-release weblate/weblate
 | caCertSecretName | string | `""` | Secret containing a custom CA cert bundle to be mounted. See https://docs.weblate.org/en/latest/admin/install.html?highlight=certificates#using-custom-certificate-authority |
 | caCertSubPath | string | `""` | Name of the CA cert bundle in the secret, e.g. ca-certificates.crt or ca-bundle.crt |
 | configOverride | string | `""` | Config override. See https://docs.weblate.org/en/latest/admin/install/docker.html#custom-configuration-files |
+| containerSecurityContext.enabled | bool | `false` |  |
 | debug | string | `"0"` | Enable debugging |
 | defaultFromEmail | string | `""` | From email for outgoing emails |
 | emailHost | string | `""` | Host for sending emails |
@@ -68,6 +69,7 @@ $ helm install my-release weblate/weblate
 | persistence.existingClaim | string | `""` | Use an existing volume claim |
 | persistence.filestore_dir | string | `"/app/data"` |  |
 | persistence.size | string | `"10Gi"` |  |
+| podSecurityContext.enabled | bool | `true` |  |
 | podSecurityContext.fsGroup | int | `1000` |  |
 | postgresql.enabled | bool | `true` |  |
 | postgresql.postgresqlDatabase | string | `"weblate"` |  |
@@ -82,7 +84,6 @@ $ helm install my-release weblate/weblate
 | redis.redisHost | string | `None` | External redis database endpoint, to be used if `redis.enabled == false` |
 | replicaCount | int | `1` |  |
 | resources | object | `{}` |  |
-| securityContext | object | `{}` |  |
 | serverEmail | string | `""` | Sender for outgoing emails |
 | service.annotations | string | `nil` |  |
 | service.port | int | `80` |  |

--- a/charts/weblate/README.md
+++ b/charts/weblate/README.md
@@ -1,6 +1,6 @@
 # weblate
 
-![Version: 0.4.13](https://img.shields.io/badge/Version-0.4.13-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 4.14](https://img.shields.io/badge/AppVersion-4.14-informational?style=flat-square)
+![Version: 0.4.14](https://img.shields.io/badge/Version-0.4.14-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 4.14](https://img.shields.io/badge/AppVersion-4.14-informational?style=flat-square)
 
 Weblate is a free web-based translation management system.
 

--- a/charts/weblate/templates/deployment.yaml
+++ b/charts/weblate/templates/deployment.yaml
@@ -28,12 +28,14 @@ spec:
         {{- toYaml . | nindent 8 }}
     {{- end }}
       serviceAccountName: {{ template "weblate.serviceAccountName" . }}
-      securityContext:
-        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      {{- if .Values.podSecurityContext.enabled }}
+      securityContext: {{- omit .Values.podSecurityContext "enabled" | toYaml | nindent 8 }}
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
-          securityContext:
-            {{- toYaml .Values.securityContext | nindent 12 }}
+          {{- if .Values.containerSecurityContext.enabled }}
+          securityContext: {{- omit .Values.containerSecurityContext "enabled" | toYaml | nindent 12 }}
+          {{- end }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:

--- a/charts/weblate/values.yaml
+++ b/charts/weblate/values.yaml
@@ -74,9 +74,11 @@ serviceAccount:
   name:
 
 podSecurityContext:
+  enabled: true
   fsGroup: 1000
 
-securityContext: {}
+containerSecurityContext:
+  enabled: false
   # capabilities:
   #   drop:
   #   - ALL


### PR DESCRIPTION
Fix issue #184

## Proposed changes

This PR aligns Weblate Helm Chart with attributes of postgresql+redis subcharts that allow disabling podSecurityContext and containerSecurityContext in conservative manner.

It allows also to fix a limitation of Helm ([issue 9136](https://github.com/helm/helm/issues/9136)) that doesn't allow to remove keys when used as a subchart.

## Checklist

- [x] Lint and unit tests pass locally with my changes.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added documentation to describe my feature.
- [x] I have squashed my commits into logic units.
- [x] I have described the changes in the commit messages.

## Other information

-