### PR TITLE
Allow to use existing secret to securely set credentials

### DIFF
--- a/charts/weblate/Chart.yaml
+++ b/charts/weblate/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 4.14.1
 description: Weblate is a free web-based translation management system.
 name: weblate
 type: application
-version: 0.4.16
+version: 0.4.17
 home: https://weblate.org/
 icon: https://s.weblate.org/cdn/weblate.svg
 maintainers:

--- a/charts/weblate/README.md
+++ b/charts/weblate/README.md
@@ -1,6 +1,6 @@
 # weblate
 
-![Version: 0.4.16](https://img.shields.io/badge/Version-0.4.16-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 4.14.1](https://img.shields.io/badge/AppVersion-4.14.1-informational?style=flat-square)
+![Version: 0.4.17](https://img.shields.io/badge/Version-0.4.17-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 4.14.1](https://img.shields.io/badge/AppVersion-4.14.1-informational?style=flat-square)
 
 Weblate is a free web-based translation management system.
 

--- a/charts/weblate/README.md
+++ b/charts/weblate/README.md
@@ -48,6 +48,7 @@ $ helm install my-release weblate/weblate
 | emailSSL | bool | `true` | Use SSL when sending emails |
 | emailTLS | bool | `true` | Use TLS when sending emails |
 | emailUser | string | `""` | User name for sending emails |
+| existingSecret | string | `""` | Name of existing secret, Make sure it contains the keys postgresql-user, postgresql-password, redis-password, email-user, email-password, admin-user, admin-password Also note to set the existingSecret values for the Redis and Postgresql subcharts |
 | externalSecretName | string | `""` | An external secret, in the same namespace, that will be use to set additionnal (environment) configs. |
 | extraConfig | object | `{}` | Additional (environment) configs. Values will be evaluated as templates. See https://docs.weblate.org/en/latest/admin/install/docker.html#docker-environment |
 | extraSecretConfig | object | `{}` | Same as `extraConfig`, but created as secrets. Values will be evaluated as Helm templates |
@@ -75,12 +76,16 @@ $ helm install my-release weblate/weblate
 | podSecurityContext.fsGroup | int | `1000` |  |
 | postgresql.auth.database | string | `"weblate"` |  |
 | postgresql.auth.enablePostgresUser | bool | `true` |  |
+| postgresql.auth.existingSecret | string | `""` |  |
 | postgresql.auth.postgresPassword | string | `"weblate"` |  |
+| postgresql.auth.secretKeys.userPasswordKey | string | `"postgresql-password"` |  |
 | postgresql.enabled | bool | `true` |  |
 | postgresql.postgresqlHost | string | `None` | External postgres database endpoint, to be used if `postgresql.enabled == false` |
 | postgresql.service.ports.postgresql | int | `5432` |  |
 | redis.architecture | string | `"standalone"` |  |
 | redis.auth.enabled | bool | `true` |  |
+| redis.auth.existingSecret | string | `""` |  |
+| redis.auth.existingSecretPasswordKey | string | `"redis-password"` |  |
 | redis.auth.password | string | `"weblate"` |  |
 | redis.db | int | `1` |  |
 | redis.enabled | bool | `true` |  |

--- a/charts/weblate/templates/deployment.yaml
+++ b/charts/weblate/templates/deployment.yaml
@@ -55,12 +55,20 @@ spec:
             - name: POSTGRES_USER
               valueFrom:
                 secretKeyRef:
+                  {{ if not .Values.existingSecret -}}
                   name: {{ include "weblate.fullname" . }}
+                  {{- else }}
+                  name: {{ .Values.existingSecret }}
+                  {{- end }}
                   key: postgresql-user
             - name: POSTGRES_PASSWORD
               valueFrom:
                 secretKeyRef:
+                  {{ if not .Values.existingSecret -}}
                   name: {{ include "weblate.fullname" . }}
+                  {{- else }}
+                  name: {{ .Values.existingSecret }}
+                  {{- end }}
                   key: postgresql-password
             {{- end }}
             {{- if .Values.redis.enabled }}
@@ -71,7 +79,11 @@ spec:
             - name: REDIS_PASSWORD
               valueFrom:
                 secretKeyRef:
+                  {{ if not .Values.existingSecret -}}
                   name: {{ include "weblate.fullname" . }}
+                  {{ else }}
+                  name: {{ .Values.existingSecret }}
+                  {{- end }}
                   key: redis-password
             {{- end }}
             - name: WEBLATE_ADMIN_EMAIL
@@ -79,12 +91,20 @@ spec:
             - name: WEBLATE_ADMIN_NAME
               valueFrom:
                 secretKeyRef:
+                  {{ if not .Values.existingSecret -}}
                   name: {{ include "weblate.fullname" . }}
+                  {{- else }}
+                  name: {{ .Values.existingSecret }}
+                  {{- end }}
                   key: admin-user
             - name: WEBLATE_ADMIN_PASSWORD
               valueFrom:
                 secretKeyRef:
+                  {{ if not .Values.existingSecret -}}
                   name: {{ include "weblate.fullname" . }}
+                  {{- else }}
+                  name: {{ .Values.existingSecret }}
+                  {{- end }}
                   key: admin-password
             - name: WEBLATE_SITE_TITLE
               value: "{{ .Values.siteTitle }}"
@@ -101,12 +121,20 @@ spec:
             - name: WEBLATE_EMAIL_USER
               valueFrom:
                 secretKeyRef:
+                  {{ if not .Values.existingSecret -}}
                   name: {{ include "weblate.fullname" . }}
+                  {{- else }}
+                  name: {{ .Values.existingSecret }}
+                  {{- end }}
                   key: email-user
             - name: WEBLATE_EMAIL_PASSWORD
               valueFrom:
                 secretKeyRef:
+                  {{ if not .Values.existingSecret -}}
                   name: {{ include "weblate.fullname" . }}
+                  {{- else }}
+                  name: {{ .Values.existingSecret }}
+                  {{- end }}
                   key: email-password
             - name: WEBLATE_SERVER_EMAIL
               value: "{{ .Values.serverEmail }}"

--- a/charts/weblate/templates/secret.yaml
+++ b/charts/weblate/templates/secret.yaml
@@ -1,3 +1,4 @@
+{{ if not .Values.existingSecret }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -14,3 +15,4 @@ data:
   email-password: {{ .Values.emailPassword | b64enc | quote }}
   admin-user: {{ .Values.adminUser | b64enc | quote }}
   admin-password: {{ .Values.adminPassword | b64enc | quote }}
+{{ end }}

--- a/charts/weblate/values.yaml
+++ b/charts/weblate/values.yaml
@@ -24,6 +24,11 @@ adminUser: ''
 # adminPassword -- Password of Admin Account
 adminPassword: ''
 
+# existingSecret -- Name of existing secret,
+# Make sure it contains the keys postgresql-user, postgresql-password, redis-password, email-user, email-password, admin-user, admin-password
+# Also note to set the existingSecret values for the Redis and Postgresql subcharts
+existingSecret: ''
+
 # siteTile -- Site title
 siteTitle: Weblate
 # siteDomain -- Site domain
@@ -154,6 +159,9 @@ postgresql:
     enablePostgresUser: true
     postgresPassword: weblate
     database: weblate
+    existingSecret: ''
+    secretKeys:
+      userPasswordKey: postgresql-password
   service:
     ports:
       postgresql: 5432
@@ -168,6 +176,8 @@ redis:
   auth:
     enabled: true
     password: weblate
+    existingSecret: ''
+    existingSecretPasswordKey: redis-password
   db: 1
   enabled: true
   # redis.redisHost -- External redis database endpoint, to be


### PR DESCRIPTION
## Proposed changes
At the time of writing it was not possible to use an existing secret to bypass the plaintext credentials in the [values.yaml](charts/weblate/values.yaml). The change introduces the possibility to use an existing secret to read the credentials from. This allows the user to 

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask. We're here to
help! This is simply a reminder of what we are going to look for before merging
your code.
-->

- [x] Lint and unit tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added documentation to describe my feature.
- [x] I have squashed my commits into logic units.
- [x] I have described the changes in the commit messages.