### PR TITLE
Gw/chart fix for external postgres

### DIFF
--- a/charts/weblate/Chart.yaml
+++ b/charts/weblate/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 4.15.2
 description: Weblate is a free web-based translation management system.
 name: weblate
 type: application
-version: 0.4.21
+version: 0.4.22
 home: https://weblate.org/
 icon: https://s.weblate.org/cdn/weblate.svg
 maintainers:

--- a/charts/weblate/README.md
+++ b/charts/weblate/README.md
@@ -78,10 +78,11 @@ $ helm install my-release weblate/weblate
 | postgresql.auth.enablePostgresUser | bool | `true` |  |
 | postgresql.auth.existingSecret | string | `""` |  |
 | postgresql.auth.postgresPassword | string | `"weblate"` |  |
+| postgresql.auth.postgresqlUsername | string | `nil` |  |
 | postgresql.auth.secretKeys.userPasswordKey | string | `"postgresql-password"` |  |
 | postgresql.enabled | bool | `true` |  |
 | postgresql.postgresqlHost | string | `None` | External postgres database endpoint, to be used if `postgresql.enabled == false` |
-| postgresql.service.ports.postgresql | int | `5432` |  |
+| postgresql.service.ports | int | `5432` |  |
 | redis.architecture | string | `"standalone"` |  |
 | redis.auth.enabled | bool | `true` |  |
 | redis.auth.existingSecret | string | `""` |  |

--- a/charts/weblate/README.md
+++ b/charts/weblate/README.md
@@ -78,7 +78,7 @@ $ helm install my-release weblate/weblate
 | postgresql.auth.enablePostgresUser | bool | `true` |  |
 | postgresql.auth.existingSecret | string | `""` |  |
 | postgresql.auth.postgresPassword | string | `"weblate"` |  |
-| postgresql.auth.postgresqlUsername | string | `nil` |  |
+| postgresql.auth.postgresqlUsername | string | `""` |  |
 | postgresql.auth.secretKeys.userPasswordKey | string | `"postgresql-password"` |  |
 | postgresql.enabled | bool | `true` |  |
 | postgresql.postgresqlHost | string | `None` | External postgres database endpoint, to be used if `postgresql.enabled == false` |

--- a/charts/weblate/README.md
+++ b/charts/weblate/README.md
@@ -1,6 +1,6 @@
 # weblate
 
-![Version: 0.4.21](https://img.shields.io/badge/Version-0.4.21-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 4.15.2](https://img.shields.io/badge/AppVersion-4.15.2-informational?style=flat-square)
+![Version: 0.4.22](https://img.shields.io/badge/Version-0.4.22-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 4.15.2](https://img.shields.io/badge/AppVersion-4.15.2-informational?style=flat-square)
 
 Weblate is a free web-based translation management system.
 

--- a/charts/weblate/templates/deployment.yaml
+++ b/charts/weblate/templates/deployment.yaml
@@ -45,7 +45,7 @@ spec:
               containerPort: 8080
               protocol: TCP
           env:
-            {{- if .Values.postgresql.enabled }}
+            {{- if or (eq .Values.postgresql.enabled true) (ne .Values.postgresql.postgresqlHost nil) }}
             - name: POSTGRES_DATABASE
               value: {{ .Values.postgresql.auth.database | default (include "weblate.fullname" .) }}
             - name: POSTGRES_HOST

--- a/charts/weblate/templates/secret.yaml
+++ b/charts/weblate/templates/secret.yaml
@@ -8,8 +8,12 @@ metadata:
 {{ include "weblate.labels" . | indent 4 }}
 type: Opaque
 data:
+  {{- if .Values.postgresql.auth.enablePostgresUser }}
   postgresql-user: {{ "postgres" | b64enc | quote }}
-  postgresql-password: {{ .Values.postgresql.auth.postgresPassword | b64enc | quote }}
+  {{- else }}
+  postgresql-user: {{ .Values.postgresql.auth.postgresqlUsername | b64enc | quote }}
+  {{- end }}
+  postgresql-password: {{ .Values.postgresql.auth.postgresqlPassword | b64enc | quote }}
   redis-password: {{ .Values.redis.auth.password | b64enc | quote }}
   email-user: {{ .Values.emailUser | b64enc | quote }}
   email-password: {{ .Values.emailPassword | b64enc | quote }}

--- a/charts/weblate/values.yaml
+++ b/charts/weblate/values.yaml
@@ -159,7 +159,7 @@ postgresql:
   # To user your own PostgresUsername set enablePostgresUser: false and
   # fill in postgresqlUsername
     enablePostgresUser: true
-    postgresqlUsername:
+    postgresqlUsername: ''
     postgresPassword: weblate
     database: weblate
     existingSecret: ''

--- a/charts/weblate/values.yaml
+++ b/charts/weblate/values.yaml
@@ -156,10 +156,10 @@ postgresql:
   # PostgreSQL user should be a superuser to
   # be able to install pg_trgm extension. Alternatively you can install it
   # manually prior starting Weblate.
-  # To user your own PostgresUsername set enablePostgresUser: false and 
+  # To user your own PostgresUsername set enablePostgresUser: false and
   # fill in postgresqlUsername
     enablePostgresUser: true
-    postgresqlUsername: 
+    postgresqlUsername:
     postgresPassword: weblate
     database: weblate
     existingSecret: ''

--- a/charts/weblate/values.yaml
+++ b/charts/weblate/values.yaml
@@ -156,15 +156,17 @@ postgresql:
   # PostgreSQL user should be a superuser to
   # be able to install pg_trgm extension. Alternatively you can install it
   # manually prior starting Weblate.
+  # To user your own PostgresUsername set enablePostgresUser: false and 
+  # fill in postgresqlUsername
     enablePostgresUser: true
+    postgresqlUsername: 
     postgresPassword: weblate
     database: weblate
     existingSecret: ''
     secretKeys:
       userPasswordKey: postgresql-password
   service:
-    ports:
-      postgresql: 5432
+    ports: 5432
   enabled: true
   # postgresql.postgresqlHost -- External postgres database endpoint, to be
   # used if `postgresql.enabled == false`


### PR DESCRIPTION
## Proposed changes

<!--
Describe the big picture of your changes here to communicate to the maintainers
why we should accept this pull request. If it fixes a bug or resolves a feature
request, be sure to link to that issue.
-->
When updating Weblate using an existing Postgresql Instance, the Helm chart will fail / Weblate will not start due to missing Posgresql Enviroment variables.
This is due to the fact, that postgresql.enabled must be set to false to not having a postgresql pod created  during deployment, but the env. variables willl only be set, if the postgresql.enabled is set to true (see current deployment.yaml).

To avaid this, I extended the check in the deployment.yaml to not only look at postgresql.enabled but also if postgresql.postgresqlHost is set. If the one or the other condition is true, the env. variables must be set.

I also extended the secrets.yaml to include the before exting postgresql.auth.postgresqlUsername. For an existing Postgresql Instance it would be helpfull to either use an own username or to use the standard one defined in secrets.yaml. So I check if enablePostgresUser is set to true, then use the "postgres" username, otherwise the value is read from postgresqlUsername. For this I put postgresqlUsername back into values.yaml

Last but not least, the value for the Postgresql port is read from postgresql.service.port in depolyment.yaml. In the values.yaml file, the port information is in postgresql.service.port.postgresql. I chnaged the position in the values .yaml for the port, as this would prevent the deployment to function.


## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask. We're here to
help! This is simply a reminder of what we are going to look for before merging
your code.
-->

- [x] Lint and unit tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added documentation to describe my feature.
- [x] I have squashed my commits into logic units.
- [x] I have described the changes in the commit messages.

## Other information

<!--
Any other information that is important to this PR such as screenshots of how
the component looks before and after the change.
-->
