### PR TITLE
add support for custom deployment init containers and sidecars

### DIFF
--- a/charts/weblate/README.md
+++ b/charts/weblate/README.md
@@ -52,8 +52,6 @@ $ helm install my-release weblate/weblate
 | externalSecretName | string | `""` | An external secret, in the same namespace, that will be use to set additionnal (environment) configs. |
 | extraConfig | object | `{}` | Additional (environment) configs. Values will be evaluated as templates. See https://docs.weblate.org/en/latest/admin/install/docker.html#docker-environment |
 | extraSecretConfig | object | `{}` | Same as `extraConfig`, but created as secrets. Values will be evaluated as Helm templates |
-| initContainers | list | `[]` | List of init containers to add to the pod. Values will be evaluated as Helm templates |
-| sidecars | list | `[]` | List of additional containers to add to the pod. Values will be evaluated as Helm templates |
 | fullnameOverride | string | `""` |  |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | image.repository | string | `"weblate/weblate"` |  |
@@ -66,6 +64,7 @@ $ helm install my-release weblate/weblate
 | ingress.hosts[0].paths[0].pathType | string | `"Prefix"` |  |
 | ingress.ingressClassName | string | `""` |  |
 | ingress.tls | list | `[]` |  |
+| initContainers | list | `[]` | List of init containers to add to the pod. Values will be evaluated as Helm templates |
 | labels | object | `{}` | custom labels |
 | nameOverride | string | `""` |  |
 | nodeSelector | object | `{}` |  |
@@ -100,6 +99,7 @@ $ helm install my-release weblate/weblate
 | service.type | string | `"ClusterIP"` |  |
 | serviceAccount.create | bool | `true` |  |
 | serviceAccount.name | string | `nil` |  |
+| sidecars | list | `[]` | List of additional containers to add to the pod. Values will be evaluated as Helm templates |
 | siteDomain | string | `"chart-example.local"` | Site domain |
 | siteTitle | string | `"Weblate"` |  |
 | tolerations | list | `[]` |  |

--- a/charts/weblate/README.md
+++ b/charts/weblate/README.md
@@ -52,6 +52,8 @@ $ helm install my-release weblate/weblate
 | externalSecretName | string | `""` | An external secret, in the same namespace, that will be use to set additionnal (environment) configs. |
 | extraConfig | object | `{}` | Additional (environment) configs. Values will be evaluated as templates. See https://docs.weblate.org/en/latest/admin/install/docker.html#docker-environment |
 | extraSecretConfig | object | `{}` | Same as `extraConfig`, but created as secrets. Values will be evaluated as Helm templates |
+| initContainers | list | `[]` | List of init containers to add to the pod. Values will be evaluated as Helm templates |
+| sidecars | list | `[]` | List of additional containers to add to the pod. Values will be evaluated as Helm templates |
 | fullnameOverride | string | `""` |  |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | image.repository | string | `"weblate/weblate"` |  |

--- a/charts/weblate/templates/deployment.yaml
+++ b/charts/weblate/templates/deployment.yaml
@@ -32,6 +32,10 @@ spec:
       securityContext:
         {{- omit .Values.podSecurityContext "enabled" | toYaml | nindent 8 }}
       {{- end }}
+      {{- with .Values.initContainers }}
+      initContainers:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           {{- if .Values.containerSecurityContext.enabled }}
@@ -191,6 +195,9 @@ spec:
             {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+        {{- if .Values.sidecars }}
+        {{- toYaml .Values.sidecars | nindent 8 }}
+        {{- end }}
       volumes:
         - name: weblate-config
           configMap:

--- a/charts/weblate/values.yaml
+++ b/charts/weblate/values.yaml
@@ -68,6 +68,11 @@ extraConfig: {}
 # extraSecretConfig -- Same as `extraConfig`, but created as secrets. Values will be evaluated as Helm templates
 extraSecretConfig: {}
 
+# initContainers -- List of init containers to add to the pod. Values will be evaluated as Helm templates
+initContainers: []
+# sidecars -- List of additional containers to add to the pod. Values will be evaluated as Helm templates
+sidecars: []
+
 # externalSecretName -- An external secret, in the same namespace, that will be use to set additionnal
 # (environment) configs.
 externalSecretName: ''


### PR DESCRIPTION
both sidecar- and init containers are rendered as raw object lists to support custom logic and workflows.

## Proposed changes

<!--
Describe the big picture of your changes here to communicate to the maintainers
why we should accept this pull request. If it fixes a bug or resolves a feature
request, be sure to link to that issue.
-->

init containers can be used to fix permission issues of PVCs
side cars are used for tight application coupling such
as metrics export, maintenance tasks, or automations.

closes #130

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask. We're here to
help! This is simply a reminder of what we are going to look for before merging
your code.
-->

- [x] Lint and unit tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added documentation to describe my feature.
- [x] I have squashed my commits into logic units.
- [x] I have described the changes in the commit messages.

## Other information

<!--
Any other information that is important to this PR such as screenshots of how
the component looks before and after the change.
-->
