### PR TITLE
Web context management when running behind a reverse proxy

### DIFF
--- a/charts/weblate/Chart.yaml
+++ b/charts/weblate/Chart.yaml
@@ -4,7 +4,7 @@ appVersion: 4.16.4-1
 description: Weblate is a free web-based translation management system.
 name: weblate
 type: application
-version: 0.4.24
+version: 0.4.25
 home: https://weblate.org/
 icon: https://s.weblate.org/cdn/weblate.svg
 maintainers:

--- a/charts/weblate/README.md
+++ b/charts/weblate/README.md
@@ -1,6 +1,6 @@
 # weblate
 
-![Version: 0.4.24](https://img.shields.io/badge/Version-0.4.24-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 4.16.4-1](https://img.shields.io/badge/AppVersion-4.16.4--1-informational?style=flat-square)
+![Version: 0.4.25](https://img.shields.io/badge/Version-0.4.25-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 4.16.4-1](https://img.shields.io/badge/AppVersion-4.16.4--1-informational?style=flat-square)
 
 Weblate is a free web-based translation management system.
 

--- a/charts/weblate/README.md
+++ b/charts/weblate/README.md
@@ -103,7 +103,7 @@ $ helm install my-release weblate/weblate
 | serviceAccount.name | string | `nil` |  |
 | sidecars | list | `[]` | List of additional containers to add to the pod. Values will be evaluated as Helm templates |
 | siteDomain | string | `"chart-example.local"` | Site domain |
+| sitePrefix | string | `""` | Site Prefix (ex: /weblate) |
 | siteTitle | string | `"Weblate"` |  |
-| sitePrefix | string | `""` | Web context (ex: /weblate /translation) when running behind a reverse proxy |
 | tolerations | list | `[]` |  |
 | updateStrategy | string | `"Recreate"` |  |

--- a/charts/weblate/README.md
+++ b/charts/weblate/README.md
@@ -104,5 +104,6 @@ $ helm install my-release weblate/weblate
 | sidecars | list | `[]` | List of additional containers to add to the pod. Values will be evaluated as Helm templates |
 | siteDomain | string | `"chart-example.local"` | Site domain |
 | siteTitle | string | `"Weblate"` |  |
+| sitePrefix | string | `""` | Web context (ex: /weblate /translation) when running behind a reverse proxy |
 | tolerations | list | `[]` |  |
 | updateStrategy | string | `"Recreate"` |  |

--- a/charts/weblate/templates/NOTES.txt
+++ b/charts/weblate/templates/NOTES.txt
@@ -2,7 +2,7 @@
 {{- if .Values.ingress.enabled }}
 {{- range $host := .Values.ingress.hosts }}
   {{- range .paths }}
-  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ . }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ .path }}
   {{- end }}
 {{- end }}
 {{- else if contains "NodePort" .Values.service.type }}

--- a/charts/weblate/templates/deployment.yaml
+++ b/charts/weblate/templates/deployment.yaml
@@ -152,6 +152,10 @@ spec:
             - name: REQUESTS_CA_BUNDLE
               value: /{{ .Values.caCertSubPath }}
             {{- end }}
+            {{- if .Values.sitePrefix }}
+            - name: WEBLATE_URL_PREFIX
+              value: {{ .Values.sitePrefix }}
+            {{- end }}
             {{- range $key, $value := .Values.extraConfig }}
             - name: {{ $key | quote }}
               value: |-
@@ -170,14 +174,14 @@ spec:
           {{- end }}
           livenessProbe:
             httpGet:
-              path: /healthz/
+              path: {{ .Values.sitePrefix }}/healthz/
               port: http
             failureThreshold: 10
             initialDelaySeconds: 90
             periodSeconds: 30
           readinessProbe:
             httpGet:
-              path: /healthz/
+              path: {{ .Values.sitePrefix }}/healthz/
               port: http
             failureThreshold: 5
             initialDelaySeconds: 90

--- a/charts/weblate/values.yaml
+++ b/charts/weblate/values.yaml
@@ -33,6 +33,8 @@ existingSecret: ''
 siteTitle: Weblate
 # siteDomain -- Site domain
 siteDomain: chart-example.local
+# sitePrefix -- Site Prefix (ex: /weblate)
+sitePrefix: ''
 
 # emailHost -- Host for sending emails
 emailHost: ''


### PR DESCRIPTION
## Proposed changes

Hello,
I propose to add an entry in values.yaml to handle the WEBLATE_URL_PREFIX value (when running behind a reverse proxy)
I've fixed the liveness and readyness probe url (/healthz) following issue:

When running behind a reverse proxy (ex: /weblate), the liveness and readyness probes checks /healthz (and not /weblate/healthz) , so always gets a 404, and the pod never gets ready to run.

## Checklist

- [x] Lint and unit tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added documentation to describe my feature.
- [ ] I have squashed my commits into logic units.
- [x] I have described the changes in the commit messages.

## Other information
N/A
