### PR TITLE
feat(deployment): Deploy weblate without 'postgres' or 'redis' upstre…

### DIFF
--- a/charts/weblate/README.md
+++ b/charts/weblate/README.md
@@ -81,6 +81,7 @@ $ helm install my-release weblate/weblate
 | postgresql.auth.enablePostgresUser | bool | `true` |  |
 | postgresql.auth.existingSecret | string | `""` |  |
 | postgresql.auth.postgresPassword | string | `"weblate"` |  |
+| postgresql.auth.userName | string | `""` | default "postgres"  |
 | postgresql.auth.secretKeys.userPasswordKey | string | `"postgresql-password"` |  |
 | postgresql.enabled | bool | `true` |  |
 | postgresql.postgresqlHost | string | `None` | External postgres database endpoint, to be used if `postgresql.enabled == false` |

--- a/charts/weblate/README.md
+++ b/charts/weblate/README.md
@@ -81,8 +81,8 @@ $ helm install my-release weblate/weblate
 | postgresql.auth.enablePostgresUser | bool | `true` |  |
 | postgresql.auth.existingSecret | string | `""` |  |
 | postgresql.auth.postgresPassword | string | `"weblate"` |  |
-| postgresql.auth.userName | string | `""` | default "postgres"  |
 | postgresql.auth.secretKeys.userPasswordKey | string | `"postgresql-password"` |  |
+| postgresql.auth.userName | string | `""` |  |
 | postgresql.enabled | bool | `true` |  |
 | postgresql.postgresqlHost | string | `None` | External postgres database endpoint, to be used if `postgresql.enabled == false` |
 | postgresql.service.ports.postgresql | int | `5432` |  |

--- a/charts/weblate/templates/deployment.yaml
+++ b/charts/weblate/templates/deployment.yaml
@@ -49,13 +49,12 @@ spec:
               containerPort: 8080
               protocol: TCP
           env:
-            {{- if .Values.postgresql.enabled }}
             - name: POSTGRES_DATABASE
               value: {{ .Values.postgresql.auth.database | default (include "weblate.fullname" .) }}
             - name: POSTGRES_HOST
               value: "{{ .Values.postgresql.postgresqlHost | default (include "weblate.postgresql.fullname" .) }}"
             - name: POSTGRES_PORT
-              value: "{{ .Values.postgresql.service.port }}"
+              value: "{{ .Values.postgresql.service.port | default 5432}}"
             - name: POSTGRES_USER
               valueFrom:
                 secretKeyRef:
@@ -68,14 +67,16 @@ spec:
             - name: POSTGRES_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  {{ if not .Values.existingSecret -}}
+                  {{ if and (not .Values.existingSecret) (not .Values.postgresql.auth.existingSecret) -}}
                   name: {{ include "weblate.fullname" . }}
+                  key: postgresql-password
+                  {{ else if and (not .Values.existingSecret) (.Values.postgresql.auth.existingSecret) -}}
+                  name: {{ .Values.postgresql.auth.existingSecret }}
+                  key: {{ .Values.postgresql.auth.secretKeys.userPasswordKey }}
                   {{- else }}
                   name: {{ .Values.existingSecret }}
-                  {{- end }}
                   key: postgresql-password
-            {{- end }}
-            {{- if .Values.redis.enabled }}
+                  {{- end }}
             - name: REDIS_HOST
               value: "{{ .Values.redis.redisHost | default (include "weblate.redis.fullname" .) }}"
             - name: REDIS_DB
@@ -83,13 +84,16 @@ spec:
             - name: REDIS_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  {{ if not .Values.existingSecret -}}
+                  {{ if and (not .Values.existingSecret) (not .Values.redis.auth.existingSecret) -}}
                   name: {{ include "weblate.fullname" . }}
+                  key: redis-password
+                  {{ else if and (not .Values.existingSecret) (.Values.redis.auth.existingSecret) -}}
+                  name: {{ .Values.redis.auth.existingSecret }}
+                  key: {{ .Values.redis.auth.existingSecretPasswordKey }}
                   {{ else }}
                   name: {{ .Values.existingSecret }}
-                  {{- end }}
                   key: redis-password
-            {{- end }}
+                  {{- end }}
             - name: WEBLATE_ADMIN_EMAIL
               value: "{{ .Values.adminEmail }}"
             - name: WEBLATE_ADMIN_NAME

--- a/charts/weblate/templates/secret.yaml
+++ b/charts/weblate/templates/secret.yaml
@@ -8,9 +8,13 @@ metadata:
 {{ include "weblate.labels" . | indent 4 }}
 type: Opaque
 data:
-  postgresql-user: {{ "postgres" | b64enc | quote }}
+  postgresql-user: {{ .Values.postgresql.auth.userName | default "postgres" | b64enc | quote }}
+  {{ if not .Values.postgresql.auth.existingSecret }}
   postgresql-password: {{ .Values.postgresql.auth.postgresPassword | b64enc | quote }}
+  {{ end }}
+  {{ if not .Values.redis.auth.existingSecret }}
   redis-password: {{ .Values.redis.auth.password | b64enc | quote }}
+  {{ end }}
   email-user: {{ .Values.emailUser | b64enc | quote }}
   email-password: {{ .Values.emailPassword | b64enc | quote }}
   admin-user: {{ .Values.adminUser | b64enc | quote }}

--- a/charts/weblate/values.yaml
+++ b/charts/weblate/values.yaml
@@ -168,6 +168,7 @@ postgresql:
   # PostgreSQL user should be a superuser to
   # be able to install pg_trgm extension. Alternatively you can install it
   # manually prior starting Weblate.
+    userName: ''
     enablePostgresUser: true
     postgresPassword: weblate
     database: weblate


### PR DESCRIPTION
## Proposed changes

PR solves problem with deploying Weblate without Postgres/Redis upstream helm chart (from Bitnami).
At this moment if someone wants to deploy Weblate without Postgres or Redis helm chart. That person has to manually delete deployment from K8S.
If you set `postgresql.enabled == false`, Weblate is not able load ENV variables from secrets (even when `externalSecretName` is used)
Also solves Issue [142](https://github.com/WeblateOrg/helm/issues/142).

- Support for Postgres user. Current solution used only postgres user, now you can define it in `values.yaml` (default value is set to `postgres` in template)
- Add default value for Postgres port to `5432`


## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask. We're here to
help! This is simply a reminder of what we are going to look for before merging
your code.
-->

- [x] Lint and unit tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added documentation to describe my feature.
- [x] I have squashed my commits into logic units.
- [x] I have described the changes in the commit messages.

## Other information

<!--
Any other information that is important to this PR such as screenshots of how
the component looks before and after the change.
-->
