### PR TITLE
feat(deployment): make liveness and readiness probes configurable

### DIFF
--- a/charts/weblate/Chart.yaml
+++ b/charts/weblate/Chart.yaml
@@ -4,7 +4,7 @@ appVersion: 4.18.2.1
 description: Weblate is a free web-based translation management system.
 name: weblate
 type: application
-version: 0.4.29
+version: 0.4.30
 home: https://weblate.org/
 icon: https://s.weblate.org/cdn/weblate.svg
 maintainers:

--- a/charts/weblate/README.md
+++ b/charts/weblate/README.md
@@ -1,6 +1,6 @@
 # weblate
 
-![Version: 0.4.29](https://img.shields.io/badge/Version-0.4.29-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 4.18.2.1](https://img.shields.io/badge/AppVersion-4.18.2.1-informational?style=flat-square)
+![Version: 0.4.30](https://img.shields.io/badge/Version-0.4.30-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 4.18.2.1](https://img.shields.io/badge/AppVersion-4.18.2.1-informational?style=flat-square)
 
 Weblate is a free web-based translation management system.
 
@@ -68,6 +68,9 @@ $ helm install my-release weblate/weblate
 | ingress.tls | list | `[]` |  |
 | initContainers | list | `[]` | List of init containers to add to the pod. Values will be evaluated as Helm templates |
 | labels | object | `{}` | custom labels |
+| livenessProbe.failureThreshold | int | `10` |  |
+| livenessProbe.initialDelaySeconds | int | `300` |  |
+| livenessProbe.periodSeconds | int | `30` |  |
 | nameOverride | string | `""` |  |
 | nodeSelector | object | `{}` |  |
 | persistence.accessMode | string | `"ReadWriteOnce"` |  |
@@ -86,6 +89,9 @@ $ helm install my-release weblate/weblate
 | postgresql.enabled | bool | `true` |  |
 | postgresql.postgresqlHost | string | `None` | External postgres database endpoint, to be used if `postgresql.enabled == false` |
 | postgresql.service.ports.postgresql | int | `5432` |  |
+| readinessProbe.failureThreshold | int | `2` |  |
+| readinessProbe.initialDelaySeconds | int | `60` |  |
+| readinessProbe.periodSeconds | int | `30` |  |
 | redis.architecture | string | `"standalone"` |  |
 | redis.auth.enabled | bool | `true` |  |
 | redis.auth.existingSecret | string | `""` |  |

--- a/charts/weblate/templates/deployment.yaml
+++ b/charts/weblate/templates/deployment.yaml
@@ -176,20 +176,24 @@ spec:
                 name: {{ .Values.externalSecretName }}
             {{- end }}
           {{- end }}
+          {{- with .Values.livenessProbe }}
           livenessProbe:
             httpGet:
-              path: {{ .Values.sitePrefix }}/healthz/
+              path: {{ $.Values.sitePrefix }}/healthz/
               port: http
-            failureThreshold: 10
-            initialDelaySeconds: 300
-            periodSeconds: 30
+            failureThreshold: {{ .failureThreshold }}
+            initialDelaySeconds: {{ .initialDelaySeconds }}
+            periodSeconds: {{ .periodSeconds }}
+          {{- end }}
+          {{- with .Values.readinessProbe }}
           readinessProbe:
             httpGet:
-              path: {{ .Values.sitePrefix }}/healthz/
+              path: {{ $.Values.sitePrefix }}/healthz/
               port: http
-            failureThreshold: 5
-            initialDelaySeconds: 300
-            periodSeconds: 30
+            failureThreshold: {{ .failureThreshold }}
+            initialDelaySeconds: {{ .initialDelaySeconds }}
+            periodSeconds: {{ .periodSeconds }}
+          {{- end }}
           volumeMounts:
             - mountPath: {{ .Values.persistence.filestore_dir }}
               name: weblate-data

--- a/charts/weblate/values.yaml
+++ b/charts/weblate/values.yaml
@@ -163,6 +163,16 @@ tolerations: []
 
 affinity: {}
 
+livenessProbe:
+  initialDelaySeconds: 300
+  periodSeconds: 30
+  failureThreshold: 10
+
+readinessProbe:
+  initialDelaySeconds: 60
+  periodSeconds: 30
+  failureThreshold: 2
+
 postgresql:
   auth:
   # PostgreSQL user should be a superuser to


### PR DESCRIPTION
Closes #325 

## Proposed changes

A [recent change](https://github.com/WeblateOrg/helm/commit/0764e20b7c7dd553ca3d748609c73ae88fcf5956) has increased the `readinessProbe.initialDelaySeconds` to `300`, which is too high considering that bouncing the weblate deployment leads to downtime: 5 painful minutes of downtime, everytime the deployment get's slightly adjusted.

In general startup performance depends on the allocated CPU. Therefore, we should let users tweak the values.

This changeset makes the readiness and liveness probe configurable.
Additionally, the default values are adjusted:
- lower `readinessProbe.failureThreshold` -> remove container from service loadbalancing faster, e.g. in case of too much traffic
- lower `readinessProbe.initialDelaySeconds` -> the deployment controller starts probing after `60` instead of `300` seconds. This way, the container is added to the service loadbalancing up to 4 minutes earlier on startup. Note: It doesn't matter if the pod is not ready yet after the initial readiness probe fails. In contrary to the liveness probe, the deployment controller will **not** restart the pod, but simply probe again after `periodSeconds`.

## Checklist

- [x] I have added documentation to describe my feature.
- [x] I have squashed my commits into logic units.
- [x] I have described the changes in the commit messages.
