### PR TITLE
fix(deployment): use proper postgres port variable

### DIFF
--- a/charts/weblate/templates/deployment.yaml
+++ b/charts/weblate/templates/deployment.yaml
@@ -57,7 +57,7 @@ spec:
             - name: POSTGRES_HOST
               value: "{{ .Values.postgresql.postgresqlHost | default (include "weblate.postgresql.fullname" .) }}"
             - name: POSTGRES_PORT
-              value: "{{ .Values.postgresql.service.port | default 5432}}"
+              value: {{ .Values.postgresql.service.ports.postgresql | quote }}
             - name: POSTGRES_USER
               valueFrom:
                 secretKeyRef:


### PR DESCRIPTION
## Proposed changes

Alternative to #367. Fix for proper port in deployment.
Also removed `| default`, since all static default values should be in `values.yaml`.

## Checklist

- [x] Lint and unit tests pass locally with my changes.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added documentation to describe my feature.
- [x] I have squashed my commits into logic units.
- [x] I have described the changes in the commit messages.

## Other information

<!--
Any other information that is important to this PR such as screenshots of how
the component looks before and after the change.
-->
