### PR TITLE
fix(_helpers): Change name for Postgres and Redis service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,3 @@
 ## 0.5.16
 
-[BUGFIX] Fix service name for Redis and Postgres [#327](https://github.com/WeblateOrg/helm/issues/327)
+\[BUGFIX\] Fix service name for Redis and Postgres [#327](https://github.com/WeblateOrg/helm/issues/327)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,3 @@
+## 0.5.16
+
+[BUGFIX] Fix service name for Redis and Postgres [#327](https://github.com/WeblateOrg/helm/issues/327)

--- a/charts/weblate/Chart.yaml
+++ b/charts/weblate/Chart.yaml
@@ -4,7 +4,7 @@ appVersion: 5.7.2.2
 description: Weblate is a free web-based translation management system.
 name: weblate
 type: application
-version: 0.5.15
+version: 0.5.16
 home: https://weblate.org/
 icon: https://s.weblate.org/cdn/weblate.svg
 maintainers:

--- a/charts/weblate/README.md
+++ b/charts/weblate/README.md
@@ -1,6 +1,6 @@
 # weblate
 
-![Version: 0.5.15](https://img.shields.io/badge/Version-0.5.15-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 5.7.2.2](https://img.shields.io/badge/AppVersion-5.7.2.2-informational?style=flat-square)
+![Version: 0.5.16](https://img.shields.io/badge/Version-0.5.16-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 5.7.2.2](https://img.shields.io/badge/AppVersion-5.7.2.2-informational?style=flat-square)
 
 Weblate is a free web-based translation management system.
 

--- a/charts/weblate/templates/_helpers.tpl
+++ b/charts/weblate/templates/_helpers.tpl
@@ -59,11 +59,17 @@ Create the name of the service account to use
 {{- end -}}
 
 {{- define "weblate.postgresql.fullname" -}}
-{{- $fullName := include "weblate.fullname" . -}}
-{{- printf "%s-%s" $fullName "postgresql" | trunc 63 | trimSuffix "-" -}}
+{{- if .Values.postgresql.fullnameOverride }}
+{{- printf "%s" .Values.postgresql.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" (.Release.Name | trimSuffix "-" | trunc 63 | trimSuffix "-") "postgresql" -}}
+{{- end -}}
 {{- end -}}
 
 {{- define "weblate.redis.fullname" -}}
-{{- $fullName := include "weblate.fullname" . -}}
-{{- printf "%s-%s-%s" $fullName "redis" "master" | trunc 63 | trimSuffix "-" -}}
+{{- if .Values.redis.fullnameOverride }}
+{{- printf "%s-%s" (.Values.redis.fullnameOverride | trunc 63 | trimSuffix "-") "master" -}}
+{{- else -}}
+{{- printf "%s-%s-%s" (.Release.Name | trimSuffix "-" | trunc 63 | trimSuffix "-") "redis" "master" -}}
+{{- end -}}
 {{- end -}}


### PR DESCRIPTION
## Proposed changes


This PR addresses issue [327](https://github.com/WeblateOrg/helm/issues/327).
The values for `REDIS_HOST` and `POSTGRES_HOST` now align with upstream naming conventions when `redis.fullnameOverride` or `postgresql.fullnameOverride` are used.
Both values will now reference the upstream `service` name e.g `releaseName-redis-master` by default.

Helm chart version Bumped to `0.5.16`.


## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask. We're here to
help! This is simply a reminder of what we are going to look for before merging
your code.
-->

- [x] Lint and unit tests pass locally with my changes.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added documentation to describe my feature.
- [x] I have squashed my commits into logic units.
- [x] I have described the changes in the commit messages.

## Other information

Add CHANGELOG.md and now all changes will be tracked. Related to [338](https://github.com/WeblateOrg/helm/issues/338)

