### PR TITLE
fix(values): Change 'emailSSL' to False

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.5.18
+
+\[BUGFIX\] Change value `emailSSL` to `false` [#143](https://github.com/WeblateOrg/helm/issues/143)
+
 ## 0.5.16
 
 \[BUGFIX\] Fix service name for Redis and Postgres [#327](https://github.com/WeblateOrg/helm/issues/327)

--- a/charts/weblate/README.md
+++ b/charts/weblate/README.md
@@ -45,7 +45,7 @@ $ helm install my-release weblate/weblate
 | emailHost | string | `"chart-example.local"` | Host for sending emails |
 | emailPassword | string | `""` | Password for sending emails |
 | emailPort | int | `587` | Port for sending emails |
-| emailSSL | bool | `true` | Use SSL when sending emails |
+| emailSSL | bool | `false` | Use SSL when sending emails |
 | emailTLS | bool | `true` | Use TLS when sending emails |
 | emailUser | string | `""` | User name for sending emails |
 | existingSecret | string | `""` | Name of existing secret, Make sure it contains the keys postgresql-user, postgresql-password, redis-password, email-user, email-password, admin-user, admin-password Also note to set the existingSecret values for the Redis and Postgresql subcharts |

--- a/charts/weblate/values.yaml
+++ b/charts/weblate/values.yaml
@@ -43,7 +43,7 @@ emailPort: 587
 # emailTLS -- Use TLS when sending emails
 emailTLS: true
 # emailSSL -- Use SSL when sending emails
-emailSSL: true
+emailSSL: false
 # emailUser -- User name for sending emails
 emailUser: ''
 # emailPassword -- Password for sending emails


### PR DESCRIPTION
## Proposed changes
This PR fixed issue [143](https://github.com/WeblateOrg/helm/issues/143)  addressing the mutual exclusivity of TLS and SSL.

In Django, EMAIL_USE_TLS uses port `587` by default (as set in values.yaml), so `TLS` is also enabled (True) by default.
<!--
Describe the big picture of your changes here to communicate to the maintainers
why we should accept this pull request. If it fixes a bug or resolves a feature
request, be sure to link to that issue.
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask. We're here to
help! This is simply a reminder of what we are going to look for before merging
your code.
-->

- [x] Lint and unit tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added documentation to describe my feature.
- [x] I have squashed my commits into logic units.
- [x] I have described the changes in the commit messages.