### PR TITLE
fix(service): Remove tpl function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.5.20
+
+[BUGFIX] Remove `common.tplvalues.render` function [#502](https://github.com/WeblateOrg/helm/issues/502)
+
 ## 0.5.18
 
 [BUGFIX] Change value `emailSSL` to `false` [#143](https://github.com/WeblateOrg/helm/issues/143)

--- a/charts/weblate/Chart.yaml
+++ b/charts/weblate/Chart.yaml
@@ -4,7 +4,7 @@ appVersion: 5.8.4.0
 description: Weblate is a free web-based translation management system.
 name: weblate
 type: application
-version: 0.5.19
+version: 0.5.20
 home: https://weblate.org/
 icon: https://s.weblate.org/cdn/weblate.svg
 maintainers:

--- a/charts/weblate/README.md
+++ b/charts/weblate/README.md
@@ -105,7 +105,7 @@ $ helm install my-release weblate/weblate
 | resources | object | `{}` |  |
 | secretAnnotations | object | `{}` |  |
 | serverEmail | string | `""` | Sender for outgoing emails |
-| service.annotations | string | `nil` |  |
+| service.annotations | object | `{}` |  |
 | service.port | int | `80` |  |
 | service.type | string | `"ClusterIP"` |  |
 | serviceAccount.create | bool | `true` |  |

--- a/charts/weblate/README.md
+++ b/charts/weblate/README.md
@@ -1,6 +1,6 @@
 # weblate
 
-![Version: 0.5.19](https://img.shields.io/badge/Version-0.5.19-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 5.8.4.0](https://img.shields.io/badge/AppVersion-5.8.4.0-informational?style=flat-square)
+![Version: 0.5.20](https://img.shields.io/badge/Version-0.5.20-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 5.8.4.0](https://img.shields.io/badge/AppVersion-5.8.4.0-informational?style=flat-square)
 
 Weblate is a free web-based translation management system.
 

--- a/charts/weblate/templates/service.yaml
+++ b/charts/weblate/templates/service.yaml
@@ -3,10 +3,10 @@ kind: Service
 metadata:
   name: {{ include "weblate.fullname" . }}
   namespace: {{ .Release.Namespace }}
+  {{- with .Values.service.annotations }}
   annotations:
-    {{- range $key, $value := .Values.service.annotations }}
-    {{ $key }}: {{ include "common.tplvalues.render" (dict "value" $value "context" $) | quote }}
-    {{- end }}  
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   labels:
 {{ include "weblate.labels" . | indent 4 }}
 spec:

--- a/charts/weblate/values.yaml
+++ b/charts/weblate/values.yaml
@@ -122,7 +122,8 @@ service:
   type: ClusterIP
   port: 80
   # Service annotations, use key:value pairs
-  annotations:
+  annotations: {}
+    # my.annotation: "svc-annotation"
 
 ingress:
   enabled: false


### PR DESCRIPTION
## Proposed changes

Fix for [502](https://github.com/WeblateOrg/helm/issues/502). If user doesn't want to use upstream helm chart with `redis` or `postgres` function defined in service `common.tplvalues.render` doesn't work (this one is included in Bitnami charts).
 
Function removed and replaced by `with` statement
## Checklist


- [x] Lint and unit tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added documentation to describe my feature.
- [x] I have squashed my commits into logic units.
- [x] I have described the changes in the commit messages.
