### PR TITLE
Set fsGroupChangePolicy to OnRootMismatch

### DIFF
--- a/charts/weblate/README.md
+++ b/charts/weblate/README.md
@@ -81,6 +81,7 @@ $ helm install my-release weblate/weblate
 | podAnnotations | object | `{}` |  |
 | podSecurityContext.enabled | bool | `true` |  |
 | podSecurityContext.fsGroup | int | `1000` |  |
+| podSecurityContext.fsGroupChangePolicy | string | `"OnRootMismatch"` |  |
 | postgresql.auth.database | string | `"weblate"` |  |
 | postgresql.auth.enablePostgresUser | bool | `true` |  |
 | postgresql.auth.existingSecret | string | `""` |  |

--- a/charts/weblate/values.yaml
+++ b/charts/weblate/values.yaml
@@ -96,6 +96,7 @@ serviceAccount:
 podSecurityContext:
   enabled: true
   fsGroup: 1000
+  fsGroupChangePolicy: OnRootMismatch
 
 podAnnotations: {}
   # vault.security.banzaicloud.io/vault-role: "vault"


### PR DESCRIPTION
The helm chart sets `fsGroup` and the Kubernetes cluster may sets `fsGroupChangePolicy` to `Always` by default, which causes the group permissions of all files on the PVC to be adjusted every time, when the volume is mounted (e.g. container restart).

This leads to the following issues:
* With increasing PVC size and especially file count, Pod startup will become increasingly slower.
* https://github.com/WeblateOrg/weblate/issues/13897 https://github.com/WeblateOrg/docker/issues/2439

To resolve this issues, set `fsGroupChangePolicy` to `OnRootMismatch` by default. This will only change ownership and permissions when the top level root directory has incorrect permission, which should only occur with an empty PVC at the initial deployment.

>    By default, Kubernetes recursively changes ownership and permissions for the contents of each volume to match the fsGroup specified in a Pod's securityContext when that volume is mounted.
> 
>     fsGroupChangePolicy - fsGroupChangePolicy defines behavior for changing ownership and permission of the volume before being exposed inside a Pod. This field only applies to volume types that support fsGroup controlled ownership and permissions. This field has two possible values:
> 
>         OnRootMismatch: Only change permissions and ownership if the permission and the ownership of root directory does not match with expected permissions of the volume. This could help shorten the time it takes to change ownership and permission of a volume.
>         Always: Always change permission and ownership of the volume when volume is mounted. 

Source: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#configure-volume-permission-and-ownership-change-policy-for-pods