### PR TITLE
feat(deployment): Add podLabels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,16 @@
 ## 0.5.22
+
 [FEATURE] Add podLabels [#554](https://github.com/WeblateOrg/helm/pull/554)
 [BUGFIX] Remove unnecessary newlines in rendered chart [#556](https://github.com/WeblateOrg/helm/pull/556)
 
 ## 0.5.20
+
 [BUGFIX] Remove `common.tplvalues.render` function [#502](https://github.com/WeblateOrg/helm/issues/502)
 
 ## 0.5.18
+
 [BUGFIX] Change value `emailSSL` to `false` [#143](https://github.com/WeblateOrg/helm/issues/143)
 
 ## 0.5.16
+
 [BUGFIX] Fix service name for Redis and Postgres [#327](https://github.com/WeblateOrg/helm/issues/327)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.5.22
+
+[FEATURE] Add podLabels [#554](https://github.com/WeblateOrg/helm/pull/554)
+
 ## 0.5.20
 
 [BUGFIX] Remove `common.tplvalues.render` function [#502](https://github.com/WeblateOrg/helm/issues/502)

--- a/charts/weblate/Chart.yaml
+++ b/charts/weblate/Chart.yaml
@@ -4,7 +4,7 @@ appVersion: 5.10.4.0
 description: Weblate is a free web-based translation management system.
 name: weblate
 type: application
-version: 0.5.21
+version: 0.5.22
 home: https://weblate.org/
 icon: https://s.weblate.org/cdn/weblate.svg
 maintainers:

--- a/charts/weblate/README.md
+++ b/charts/weblate/README.md
@@ -79,6 +79,7 @@ $ helm install my-release weblate/weblate
 | persistence.filestore_dir | string | `"/app/data"` |  |
 | persistence.size | string | `"10Gi"` |  |
 | podAnnotations | object | `{}` |  |
+| podLabels | object | `{}` |  |
 | podSecurityContext.enabled | bool | `true` |  |
 | podSecurityContext.fsGroup | int | `1000` |  |
 | postgresql.auth.database | string | `"weblate"` |  |

--- a/charts/weblate/README.md
+++ b/charts/weblate/README.md
@@ -1,6 +1,6 @@
 # weblate
 
-![Version: 0.5.21](https://img.shields.io/badge/Version-0.5.21-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 5.10.4.0](https://img.shields.io/badge/AppVersion-5.10.4.0-informational?style=flat-square)
+![Version: 0.5.22](https://img.shields.io/badge/Version-0.5.22-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 5.10.4.0](https://img.shields.io/badge/AppVersion-5.10.4.0-informational?style=flat-square)
 
 Weblate is a free web-based translation management system.
 

--- a/charts/weblate/templates/deployment.yaml
+++ b/charts/weblate/templates/deployment.yaml
@@ -25,6 +25,9 @@ spec:
       labels:
         app.kubernetes.io/name: {{ include "weblate.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/charts/weblate/values.yaml
+++ b/charts/weblate/values.yaml
@@ -103,6 +103,8 @@ podAnnotations: {}
   # vault.security.banzaicloud.io/vault-skip-verify: "true"
   # vault.security.banzaicloud.io/vault-path: "kubernetes"
 
+podLabels: {}
+
 containerSecurityContext:
   enabled: false
   # capabilities:


### PR DESCRIPTION
Allow to add custom labels to the pod:

```
podLabels:
  label1: value1
  label2: value2
```

I deploy Weblate on a K8s cluster where it is required that certain labels are set for the pods. The helm chart supports adding labels to the deployment and other resources, but not for the deployed pods. The change is similar to the already supported custom pod annotations.