### PR TITLE
fix: remove extra newlines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.5.22
+
+[BUGFIX] Remove unnecessary newlines in rendered chart [#556](https://github.com/WeblateOrg/helm/pull/556)
+
 ## 0.5.20
 
 [BUGFIX] Remove `common.tplvalues.render` function [#502](https://github.com/WeblateOrg/helm/issues/502)

--- a/charts/weblate/Chart.yaml
+++ b/charts/weblate/Chart.yaml
@@ -4,7 +4,7 @@ appVersion: 5.10.4.0
 description: Weblate is a free web-based translation management system.
 name: weblate
 type: application
-version: 0.5.21
+version: 0.5.22
 home: https://weblate.org/
 icon: https://s.weblate.org/cdn/weblate.svg
 maintainers:

--- a/charts/weblate/README.md
+++ b/charts/weblate/README.md
@@ -1,6 +1,6 @@
 # weblate
 
-![Version: 0.5.21](https://img.shields.io/badge/Version-0.5.21-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 5.10.4.0](https://img.shields.io/badge/AppVersion-5.10.4.0-informational?style=flat-square)
+![Version: 0.5.22](https://img.shields.io/badge/Version-0.5.22-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 5.10.4.0](https://img.shields.io/badge/AppVersion-5.10.4.0-informational?style=flat-square)
 
 Weblate is a free web-based translation management system.
 

--- a/charts/weblate/templates/deployment.yaml
+++ b/charts/weblate/templates/deployment.yaml
@@ -61,7 +61,7 @@ spec:
             - name: POSTGRES_USER
               valueFrom:
                 secretKeyRef:
-                  {{ if not .Values.existingSecret -}}
+                  {{- if not .Values.existingSecret }}
                   name: {{ include "weblate.fullname" . }}
                   {{- else }}
                   name: {{ .Values.existingSecret }}
@@ -70,10 +70,10 @@ spec:
             - name: POSTGRES_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  {{ if and (not .Values.existingSecret) (not .Values.postgresql.auth.existingSecret) -}}
+                  {{- if and (not .Values.existingSecret) (not .Values.postgresql.auth.existingSecret) }}
                   name: {{ include "weblate.fullname" . }}
                   key: postgresql-password
-                  {{ else if and (not .Values.existingSecret) (.Values.postgresql.auth.existingSecret) -}}
+                  {{- else if and (not .Values.existingSecret) (.Values.postgresql.auth.existingSecret) }}
                   name: {{ .Values.postgresql.auth.existingSecret }}
                   key: {{ .Values.postgresql.auth.secretKeys.userPasswordKey }}
                   {{- else }}
@@ -87,13 +87,13 @@ spec:
             - name: REDIS_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  {{ if and (not .Values.existingSecret) (not .Values.redis.auth.existingSecret) -}}
+                  {{- if and (not .Values.existingSecret) (not .Values.redis.auth.existingSecret) }}
                   name: {{ include "weblate.fullname" . }}
                   key: redis-password
-                  {{ else if and (not .Values.existingSecret) (.Values.redis.auth.existingSecret) -}}
+                  {{- else if and (not .Values.existingSecret) (.Values.redis.auth.existingSecret) }}
                   name: {{ .Values.redis.auth.existingSecret }}
                   key: {{ .Values.redis.auth.existingSecretPasswordKey }}
-                  {{ else }}
+                  {{- else }}
                   name: {{ .Values.existingSecret }}
                   key: redis-password
                   {{- end }}
@@ -102,7 +102,7 @@ spec:
             - name: WEBLATE_ADMIN_NAME
               valueFrom:
                 secretKeyRef:
-                  {{ if not .Values.existingSecret -}}
+                  {{- if not .Values.existingSecret }}
                   name: {{ include "weblate.fullname" . }}
                   {{- else }}
                   name: {{ .Values.existingSecret }}
@@ -111,7 +111,7 @@ spec:
             - name: WEBLATE_ADMIN_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  {{ if not .Values.existingSecret -}}
+                  {{- if not .Values.existingSecret }}
                   name: {{ include "weblate.fullname" . }}
                   {{- else }}
                   name: {{ .Values.existingSecret }}
@@ -132,7 +132,7 @@ spec:
             - name: WEBLATE_EMAIL_HOST_USER
               valueFrom:
                 secretKeyRef:
-                  {{ if not .Values.existingSecret -}}
+                  {{- if not .Values.existingSecret }}
                   name: {{ include "weblate.fullname" . }}
                   {{- else }}
                   name: {{ .Values.existingSecret }}
@@ -141,7 +141,7 @@ spec:
             - name: WEBLATE_EMAIL_HOST_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  {{ if not .Values.existingSecret -}}
+                  {{- if not .Values.existingSecret }}
                   name: {{ include "weblate.fullname" . }}
                   {{- else }}
                   name: {{ .Values.existingSecret }}

--- a/charts/weblate/templates/secret.yaml
+++ b/charts/weblate/templates/secret.yaml
@@ -13,12 +13,12 @@ metadata:
 type: Opaque
 data:
   postgresql-user: {{ .Values.postgresql.auth.userName | default "postgres" | b64enc | quote }}
-  {{ if not .Values.postgresql.auth.existingSecret }}
+  {{- if not .Values.postgresql.auth.existingSecret }}
   postgresql-password: {{ .Values.postgresql.auth.postgresPassword | b64enc | quote }}
-  {{ end }}
-  {{ if not .Values.redis.auth.existingSecret }}
+  {{- end }}
+  {{- if not .Values.redis.auth.existingSecret }}
   redis-password: {{ .Values.redis.auth.password | b64enc | quote }}
-  {{ end }}
+  {{- end }}
   email-user: {{ .Values.emailUser | b64enc | quote }}
   email-password: {{ .Values.emailPassword | b64enc | quote }}
   admin-user: {{ .Values.adminUser | b64enc | quote }}


### PR DESCRIPTION
When rendering the helm chart version 0.5.21, some extra newlines are added to the Deployment and Secret.

yamllint complaints:
```
error    trailing spaces  (trailing-spaces)
```

This change adds curly brace syntax with dash ("{{-") to remove whitespace (including newlines) properly.

### Case 1 - with default empty values:

values.yaml:
```
existingSecret: ""

postgresql:
  auth:
    existingSecret: ""

redis:
  auth:
    existingSecret: ""
```
#### Deployment rendering result (relevant parts only):

Source weblate/templates/deployment.yaml:
```
            - name: POSTGRES_PASSWORD
              valueFrom:
                secretKeyRef:
                  name: test-weblate
                  key: postgresql-password
                  
            - name: REDIS_HOST
              value: "test-redis-master"
            - name: REDIS_DB
              value: "1"
            - name: REDIS_PASSWORD
              valueFrom:
                secretKeyRef:
                  name: test-weblate
                  key: redis-password
                  
            - name: WEBLATE_ADMIN_EMAIL
              value: ""
```

Source weblate/templates/secret.yaml:
```
apiVersion: v1
kind: Secret
metadata:
  name: weblate-test
  namespace: weblate-test
  labels:
    app.kubernetes.io/name: weblate
    helm.sh/chart: weblate-0.5.21
    app.kubernetes.io/instance: test
    app.kubernetes.io/version: "5.10.4.0"
    app.kubernetes.io/managed-by: Helm
type: Opaque
data:
  postgresql-user: "cG9zdGdyZXM="

  postgresql-password: "d2VibGF0ZQ=="


  redis-password: "d2VibGF0ZQ=="

  email-user: ""
  email-password: ""
  admin-user: ""
  admin-password: ""
```

### Case 2 - with existing secret:

values.yaml:
```
existingSecret: "mysecret"

postgresql:
  auth:
    existingSecret: "mysecret"

redis:
  auth:
    existingSecret: "mysecret"
```
#### Deployment rendering result (relevant parts only):

Source weblate/templates/deployment.yaml:
```
           - name: POSTGRES_USER
              valueFrom:
                secretKeyRef:

                  name: mysecret
                  key: postgresql-user
            - name: POSTGRES_PASSWORD
              valueFrom:
                secretKeyRef:
                  
                  name: mysecret
                  key: postgresql-password
            - name: REDIS_HOST
              value: "test-redis-master"
            - name: REDIS_DB
              value: "1"
            - name: REDIS_PASSWORD
              valueFrom:
                secretKeyRef:
                  
                  name: mysecret
                  key: redis-password
            - name: WEBLATE_ADMIN_EMAIL
              value: ""
            - name: WEBLATE_ADMIN_NAME
              valueFrom:
                secretKeyRef:
                  
                  name: mysecret
                  key: admin-user
            - name: WEBLATE_ADMIN_PASSWORD
              valueFrom:
                secretKeyRef:
                  
                  name: mysecret
                  key: admin-password
            - name: WEBLATE_SITE_TITLE
              value: "Weblate"
            - name: WEBLATE_SITE_DOMAIN
              value: "chart-example.local"
            - name: WEBLATE_EMAIL_HOST
              value: "chart-example.local"
            - name: WEBLATE_EMAIL_PORT
              value: "587"
            - name: WEBLATE_EMAIL_USE_TLS
              value: "true"
            - name: WEBLATE_EMAIL_USE_SSL
              value: "false"
            - name: WEBLATE_EMAIL_HOST_USER
              valueFrom:
                secretKeyRef:
                  
                  name: mysecret
                  key: email-user
            - name: WEBLATE_EMAIL_HOST_PASSWORD
              valueFrom:
                secretKeyRef:
                  
                  name: mysecret
                  key: email-password
            - name: WEBLATE_SERVER_EMAIL
              value: ""
```

helm version.BuildInfo{Version:"v3.17.2", GitCommit:"cc0bbbd6d6276b83880042c1ecb34087e84d41eb", GitTreeState:"clean", GoVersion:"go1.23.7"}
