### PR TITLE
feat(deployment): Add 'successThreshold' and 'timeoutSeconds' for Probes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.5.24
+
+[FEATURE] Add `timeoutSeconds` and `successThreshold` for **livenessProbe** and **readinessProbe** [#583](https://github.com/WeblateOrg/helm/issues/583)
+
 ## 0.5.23
 
 [BUGFIX] Only trigger a reload of the pod, if the pod template change or the configuration changes [#557](https://github.com/WeblateOrg/helm/pull/557)

--- a/charts/weblate/Chart.yaml
+++ b/charts/weblate/Chart.yaml
@@ -4,7 +4,7 @@ appVersion: 5.11.4.4
 description: Weblate is a free web-based translation management system.
 name: weblate
 type: application
-version: 0.5.23
+version: 0.5.24
 home: https://weblate.org/
 icon: https://s.weblate.org/cdn/weblate.svg
 maintainers:

--- a/charts/weblate/README.md
+++ b/charts/weblate/README.md
@@ -71,6 +71,8 @@ $ helm install my-release weblate/weblate
 | livenessProbe.failureThreshold | int | `10` |  |
 | livenessProbe.initialDelaySeconds | int | `300` |  |
 | livenessProbe.periodSeconds | int | `30` |  |
+| livenessProbe.successThreshold | int | `1` |  |
+| livenessProbe.timeoutSeconds | int | `5` |  |
 | nameOverride | string | `""` |  |
 | nodeSelector | object | `{}` |  |
 | persistence.accessMode | string | `"ReadWriteOnce"` |  |
@@ -94,6 +96,8 @@ $ helm install my-release weblate/weblate
 | readinessProbe.failureThreshold | int | `2` |  |
 | readinessProbe.initialDelaySeconds | int | `60` |  |
 | readinessProbe.periodSeconds | int | `30` |  |
+| readinessProbe.successThreshold | int | `1` |  |
+| readinessProbe.timeoutSeconds | int | `5` |  |
 | redis.architecture | string | `"standalone"` |  |
 | redis.auth.enabled | bool | `true` |  |
 | redis.auth.existingSecret | string | `""` |  |

--- a/charts/weblate/README.md
+++ b/charts/weblate/README.md
@@ -1,6 +1,6 @@
 # weblate
 
-![Version: 0.5.23](https://img.shields.io/badge/Version-0.5.23-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 5.11.4.4](https://img.shields.io/badge/AppVersion-5.11.4.4-informational?style=flat-square)
+![Version: 0.5.24](https://img.shields.io/badge/Version-0.5.24-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 5.11.4.4](https://img.shields.io/badge/AppVersion-5.11.4.4-informational?style=flat-square)
 
 Weblate is a free web-based translation management system.
 

--- a/charts/weblate/templates/deployment.yaml
+++ b/charts/weblate/templates/deployment.yaml
@@ -185,19 +185,23 @@ spec:
           {{- if .Values.livenessProbe }}
           livenessProbe:
             httpGet:
-              path: {{ $.Values.sitePrefix }}/healthz/
+              path: {{ .Values.sitePrefix }}/healthz/
               port: http
             failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
             initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
+            successThreshold: {{ .Values.livenessProbe.successThreshold }}
+            timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
             periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
           {{- end }}
           {{- if .Values.readinessProbe }}
           readinessProbe:
             httpGet:
-              path: {{ $.Values.sitePrefix }}/healthz/
+              path: {{ .Values.sitePrefix }}/healthz/
               port: http
             failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
             initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
+            successThreshold: {{ .Values.readinessProbe.successThreshold }}
+            timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
             periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
           {{- end }}
           volumeMounts:

--- a/charts/weblate/values.yaml
+++ b/charts/weblate/values.yaml
@@ -182,13 +182,17 @@ affinity: {}
 livenessProbe:
   initialDelaySeconds: 300
   periodSeconds: 30
+  timeoutSeconds: 5
   failureThreshold: 10
+  successThreshold: 1
 
 # Can be removed when running Weblate service without probes configured
 readinessProbe:
   initialDelaySeconds: 60
   periodSeconds: 30
+  timeoutSeconds: 5
   failureThreshold: 2
+  successThreshold: 1
 
 postgresql:
   auth:


### PR DESCRIPTION
PR for [583](https://github.com/WeblateOrg/helm/issues/583).

Added:
-  `successThreshold` and  `timeoutSeconds` for **livenessProbe**
-   `successThreshold` and  `timeoutSeconds` for **readinessProbe**

Set default (for both probes) values to :
- `successThreshold` - `1`
- `timeoutSeconds` - `5`

Explicitly setting `successThreshold` to `1` matches the Kubernetes default and ensures no unnecessary delay in declaring the container healthy.

Increasing `timeoutSeconds` from the Kubernetes default of  `1` to `5` allows more time for slow or resource-intensive containers to respond