### PR TITLE
fix(deps): Use bitnami images from docker.io/bitnamilegacy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.5.25
+
+[FEATURE] Add revisionHistoryLimit [#619](https://github.com/WeblateOrg/helm/pull/619)
+[BUGFIX] Use bitnami images from docker.io/bitnamilegacy for dependencies due to bitnami deprecating their public catalog. See bitnami/charts#35164
+
 ## 0.5.24
 
 [FEATURE] Add `timeoutSeconds` and `successThreshold` for **livenessProbe** and **readinessProbe** [#583](https://github.com/WeblateOrg/helm/issues/583)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 0.5.25
 
-[FEATURE] Add revisionHistoryLimit [#619](https://github.com/WeblateOrg/helm/pull/619)  
+[FEATURE] Add revisionHistoryLimit [#619](https://github.com/WeblateOrg/helm/pull/619)
 [BUGFIX] Use bitnami images from docker.io/bitnamilegacy for dependencies due to bitnami deprecating their public catalog. See bitnami/charts#35164
 
 ## 0.5.24
@@ -13,7 +13,7 @@
 
 ## 0.5.22
 
-[FEATURE] Add podLabels [#554](https://github.com/WeblateOrg/helm/pull/554)  
+[FEATURE] Add podLabels [#554](https://github.com/WeblateOrg/helm/pull/554)
 [BUGFIX] Remove unnecessary newlines in rendered chart [#556](https://github.com/WeblateOrg/helm/pull/556)
 
 ## 0.5.20

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 0.5.25
 
-[FEATURE] Add revisionHistoryLimit [#619](https://github.com/WeblateOrg/helm/pull/619)
+[FEATURE] Add revisionHistoryLimit [#619](https://github.com/WeblateOrg/helm/pull/619)  
 [BUGFIX] Use bitnami images from docker.io/bitnamilegacy for dependencies due to bitnami deprecating their public catalog. See bitnami/charts#35164
 
 ## 0.5.24
@@ -13,7 +13,7 @@
 
 ## 0.5.22
 
-[FEATURE] Add podLabels [#554](https://github.com/WeblateOrg/helm/pull/554)
+[FEATURE] Add podLabels [#554](https://github.com/WeblateOrg/helm/pull/554)  
 [BUGFIX] Remove unnecessary newlines in rendered chart [#556](https://github.com/WeblateOrg/helm/pull/556)
 
 ## 0.5.20

--- a/charts/weblate/Chart.yaml
+++ b/charts/weblate/Chart.yaml
@@ -4,7 +4,7 @@ appVersion: 5.13.0.1
 description: Weblate is a free web-based translation management system.
 name: weblate
 type: application
-version: 0.5.24
+version: 0.5.25
 home: https://weblate.org/
 icon: https://s.weblate.org/cdn/weblate.svg
 maintainers:

--- a/charts/weblate/README.md
+++ b/charts/weblate/README.md
@@ -1,6 +1,6 @@
 # weblate
 
-![Version: 0.5.25](https://img.shields.io/badge/Version-0.5.25-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 5.13.1.0](https://img.shields.io/badge/AppVersion-5.13.1.0-informational?style=flat-square)
+![Version: 0.5.25](https://img.shields.io/badge/Version-0.5.25-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 5.13.3.0](https://img.shields.io/badge/AppVersion-5.13.3.0-informational?style=flat-square)
 
 Weblate is a free web-based translation management system.
 

--- a/charts/weblate/README.md
+++ b/charts/weblate/README.md
@@ -1,6 +1,6 @@
 # weblate
 
-![Version: 0.5.24](https://img.shields.io/badge/Version-0.5.24-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 5.13.0.1](https://img.shields.io/badge/AppVersion-5.13.0.1-informational?style=flat-square)
+![Version: 0.5.25](https://img.shields.io/badge/Version-0.5.25-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 5.13.0.1](https://img.shields.io/badge/AppVersion-5.13.0.1-informational?style=flat-square)
 
 Weblate is a free web-based translation management system.
 
@@ -91,6 +91,8 @@ $ helm install my-release weblate/weblate
 | postgresql.auth.secretKeys.userPasswordKey | string | `"postgresql-password"` |  |
 | postgresql.auth.userName | string | `""` |  |
 | postgresql.enabled | bool | `true` |  |
+| postgresql.global.security.allowInsecureImages | bool | `true` |  |
+| postgresql.image.repository | string | `"bitnamilegacy/postgresql"` |  |
 | postgresql.postgresqlHost | string | `None` | External postgres database endpoint, to be used if `postgresql.enabled == false` |
 | postgresql.service.ports.postgresql | int | `5432` |  |
 | readinessProbe.failureThreshold | int | `2` |  |
@@ -105,6 +107,8 @@ $ helm install my-release weblate/weblate
 | redis.auth.password | string | `"weblate"` |  |
 | redis.db | int | `1` |  |
 | redis.enabled | bool | `true` |  |
+| redis.global.security.allowInsecureImages | bool | `true` |  |
+| redis.image.repository | string | `"bitnamilegacy/redis"` |  |
 | redis.redisHost | string | `None` | External redis database endpoint, to be used if `redis.enabled == false` |
 | replicaCount | int | `1` |  |
 | resources | object | `{}` |  |

--- a/charts/weblate/README.md
+++ b/charts/weblate/README.md
@@ -1,6 +1,6 @@
 # weblate
 
-![Version: 0.5.25](https://img.shields.io/badge/Version-0.5.25-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 5.13.0.1](https://img.shields.io/badge/AppVersion-5.13.0.1-informational?style=flat-square)
+![Version: 0.5.25](https://img.shields.io/badge/Version-0.5.25-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 5.13.1.0](https://img.shields.io/badge/AppVersion-5.13.1.0-informational?style=flat-square)
 
 Weblate is a free web-based translation management system.
 

--- a/charts/weblate/README.md
+++ b/charts/weblate/README.md
@@ -1,6 +1,6 @@
 # weblate
 
-![Version: 0.5.25](https://img.shields.io/badge/Version-0.5.25-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 5.13.3.0](https://img.shields.io/badge/AppVersion-5.13.3.0-informational?style=flat-square)
+![Version: 0.5.25](https://img.shields.io/badge/Version-0.5.25-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 5.13.3.3](https://img.shields.io/badge/AppVersion-5.13.3.3-informational?style=flat-square)
 
 Weblate is a free web-based translation management system.
 

--- a/charts/weblate/values.yaml
+++ b/charts/weblate/values.yaml
@@ -196,6 +196,12 @@ readinessProbe:
   successThreshold: 1
 
 postgresql:
+  global:
+    security:
+      # required to allow bitnamilegacy repository
+      allowInsecureImages: true
+  image:
+    repository: bitnamilegacy/postgresql
   auth:
   # PostgreSQL user should be a superuser to
   # be able to install pg_trgm extension. Alternatively you can install it
@@ -217,6 +223,12 @@ postgresql:
   postgresqlHost:
 
 redis:
+  global:
+    security:
+      # required to allow bitnamilegacy repository
+      allowInsecureImages: true
+  image:
+    repository: bitnamilegacy/redis
   architecture: standalone
   auth:
     enabled: true


### PR DESCRIPTION
Bitnami has recently announced breaking changes to there public catalog https://github.com/bitnami/charts/issues/35164 already discussed in issue https://github.com/WeblateOrg/helm/issues/600

Since August 28th the charts and the docker images have not received updates and on September 29th the docker images will be moved to `docker.io/bitnamilegacy` which breaks the chart.

Switch to `docker.io/bitnamilegacy` to be able to pull images beyond that date as a temporary workaround.