### PR TITLE
feat(pdb): Add support for 'PodDisruptionBudget'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 0.5.27
 
 [FEATURE] Add support for additional K8S resources [#731](https://github.com/WeblateOrg/helm/pull/731)
+[FEATURE] Add support for `PodDisruptionBudget` [#727](https://github.com/WeblateOrg/helm/pull/727)
 
 ## 0.5.26
 

--- a/charts/weblate/README.md
+++ b/charts/weblate/README.md
@@ -76,6 +76,7 @@ $ helm install my-release weblate/weblate
 | livenessProbe.timeoutSeconds | int | `5` |  |
 | nameOverride | string | `""` |  |
 | nodeSelector | object | `{}` |  |
+| pdb.create | bool | `false` |  |
 | persistence.accessMode | string | `"ReadWriteOnce"` |  |
 | persistence.enabled | bool | `true` |  |
 | persistence.existingClaim | string | `""` | Use an existing volume claim |

--- a/charts/weblate/templates/pdb.yaml
+++ b/charts/weblate/templates/pdb.yaml
@@ -1,0 +1,23 @@
+{{- if .Values.pdb.create }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "weblate.fullname" . }}-pdb
+  namespace: {{ .Release.Namespace }}
+  labels:
+{{ include "weblate.labels" . | indent 4 }}
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "weblate.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+      {{- with .Values.podLabels }}
+      {{- toYaml . | nindent 8 }}
+      {{- end }}
+  {{- if .Values.pdb.minAvailable }}
+  minAvailable: {{ .Values.pdb.minAvailable }}
+  {{- end }}
+  {{- if or .Values.pdb.maxUnavailable ( not .Values.pdb.minAvailable ) }}
+  maxUnavailable: {{ .Values.pdb.maxUnavailable | default 1 }}
+  {{- end }}
+{{- end }}

--- a/charts/weblate/values.yaml
+++ b/charts/weblate/values.yaml
@@ -208,6 +208,14 @@ extraObjects: []
   #       includedNamespaces:
   #         - weblate
 
+## Create Pod disruption budget
+pdb:
+  create: false
+## Minimum available instances
+#  minAvailable: ""
+## Maximum unavailable instances
+#  maxUnavailable: ""
+
 postgresql:
   global:
     security:


### PR DESCRIPTION
PR for https://github.com/WeblateOrg/helm/issues/723.

### My logic
Disabled by default (assuming most users run only one replica, so a `PDB` doesn’t make sense).

Provides an option to configure `maxUnavailable` and `minAvailable` rules.